### PR TITLE
Make tests easier to run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.yaml
+*.swp

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,24 +2,40 @@
 
 ## Helping One Newsletter fetch links from all news sites
 
-1. Make it easier to fetch links from a news site with a varied layout, e.g., one featured link, a couple of sub-featured links, and a list of other links.
+1. Make it easier to fetch links from a news site with a varied layout, e.g.,
+   one featured link, a couple of sub-featured links, and a list of other links.
 
-1. Some sites, e.g., thekitchn.com, detect automation tools via the `User-Agent` header and refuse to show content if the header has an unacceptable value. Note that it’s often easy to bypass this restriction by using a `User-Agent` header copied from (for example) a legitimate Chrome request. But is that okay/legal?
+1. Some sites, e.g., thekitchn.com, detect automation tools via the `User-Agent`
+   header and refuse to show content if the header has an unacceptable value.
+   Note that it’s often easy to bypass this restriction by using a `User-Agent`
+   header copied from (for example) a legitimate Chrome request. But is that
+   okay/legal?
 
-1. Some sites use 301 redirects with cookies in order to conduct client classification (e.g., https://www.imperva.com/blog/how-incapsula-client-classification-challenges-bots/).
+1. Some sites use 301 redirects with cookies in order to conduct client
+   classification (e.g.,
+   https://www.imperva.com/blog/how-incapsula-client-classification-challenges-bots/).
 
-One example is https://aldaily.com/articles-of-note, where the first request to the page gets a 301 redirect containing a cookie and a `Location` header pointing to the same path as before. The subsequent request uses the cookie.
+One example is https://aldaily.com/articles-of-note, where the first request to
+the page gets a 301 redirect containing a cookie and a `Location` header
+pointing to the same path as before. The subsequent request uses the cookie.
 
-Make the One Newsletter HTTP client more sophisticated so it passes client classification tests (unless it genuinely shouldn't by some commonly accepted standard). For example, we can set a `Jar` and `CheckRedirect` in the `http.Client` (https://pkg.go.dev/net/http#Client).
+Make the One Newsletter HTTP client more sophisticated so it passes client
+classification tests (unless it genuinely shouldn't by some commonly accepted
+standard). For example, we can set a `Jar` and `CheckRedirect` in the
+`http.Client` (https://pkg.go.dev/net/http#Client).
 
-1. Account for the possibility that some sites are dynamic. Maybe use a headless browser for all requests, rather than Go's HTTP client?
+1. Account for the possibility that some sites are dynamic. Maybe use a headless
+   browser for all requests, rather than Go's HTTP client?
 
 ## Making user operations easier and safer
 
 1. Make it easier to test new configurations.
 
 - More helpful warnings about bad link selectors (e.g., not specific enough).
-- Add verbose logs re: where in the automatic link parsing process One Newsletter failed to parse links. This would be useful for `oneoff`/`noemail`.
+- Add verbose logs re: where in the automatic link parsing process One
+- Newsletter failed to parse links. This would be useful for `oneoff`/`noemail`.
+- Send the first email right away rather than after the scraping interval. This
+  will make it easier to determine whether the app is running as expected.
 
 1. Include help text when the CLI is run without arguments. Also add a `help` subcommand and flag.
 
@@ -32,11 +48,13 @@ Make the One Newsletter HTTP client more sophisticated so it passes client class
 
 1. Don't include verbose logs for `oneoff` operations.
 
-1. Deprecate manual newsletter configuration (i.e., where you need to specify the link container, caption selector, and link selector).
+1. Deprecate manual newsletter configuration (i.e., where you need to specify
+   the link container, caption selector, and link selector).
 
 1. Find an alternative to static passwords stored in the config file.
 
-1. Reload or modify the One Newsletter config without exiting and restarting One Newsletter. Consider providing an option to update user configs via HTTP API.
+1. Reload or modify the One Newsletter config without exiting and restarting One
+   Newsletter. Consider providing an option to update user configs via HTTP API.
 
 1. Generate configurations automatically via a browser extension or bookmarklet.
 
@@ -46,13 +64,19 @@ Make the One Newsletter HTTP client more sophisticated so it passes client class
 
 1. Add a Makefile with “test-unit” and “test-e2e” targets. Also measure unit test coverage in a make target.
 
-1. Update the third-party licenses table using a CI job (probably using GitHub Actions) and [`go-licenses`](https://github.com/google/go-licenses). Or use a make target.
+1. Update the third-party licenses table using a CI job (probably using GitHub
+   Actions) and [`go-licenses`](https://github.com/google/go-licenses). Or use a
+   make target.
 
-1. Run e2e tests in a separate goroutine rather than a child process. This will make it easier to manage the running application, measure test coverage, and edit configuration (since it can be kept in memory). This means using a minimal `main.go` file and extracting most of the `main` function to a package that we can import in tests. Many (if not most) CLI apps in Go run e2e tests like this.
+1. Make `TestDBCleanup` (`e2e/e2e_test.go`) more deterministic and faster
+   running. Right now, it takes the longest of all e2e tests and sometimes
+   fails.
 
 ## Making the newsletter more useful
 
-1. Fetch the first sentence of each article that will be included in a newsletter and add that after the caption, giving users more of an idea of what to expect from each link.
+1. Fetch the first sentence of each article that will be included in a
+   newsletter and add that after the caption, giving users more of an idea of
+   what to expect from each link.
 
 ## Performance
 
@@ -60,4 +84,6 @@ Make the One Newsletter HTTP client more sophisticated so it passes client class
 
 ## Making accidental emails less bothersome
 
-1. Provide an opt-out option for users to prevent mis-sent email issues. This probably means exposing an HTTP endpoint to stop emails to a particular address, plus an "unsubscribe" link in the newsletter email.
+1. Provide an opt-out option for users to prevent mis-sent email issues. This
+   probably means exposing an HTTP endpoint to stop emails to a particular
+   address, plus an "unsubscribe" link in the newsletter email.

--- a/e2e/appconfig.go
+++ b/e2e/appconfig.go
@@ -1,10 +1,15 @@
 package e2e
 
 import (
-	"bytes"
-	"fmt"
-	"html/template"
-	"os"
+	"errors"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/andybalholm/cascadia"
+	"github.com/ptgott/one-newsletter/email"
+	"github.com/ptgott/one-newsletter/linksrc"
+	"github.com/ptgott/one-newsletter/userconfig"
 )
 
 // appConfigOptions is used to fill in a config template with details unique to
@@ -14,81 +19,101 @@ import (
 //
 // Fields are exported so we can use them in templates.
 type appConfigOptions struct {
+	// Required. Includes host and port.
 	SMTPServerAddress string
-	LinkSources       []mockLinksrcInfo
-	StorageDir        string
-	PollInterval      string
+	// Required
+	LinkSources []mockLinksrcInfo
+	// Required
+	StorageDir string
+	// Required
+	PollInterval string
+	OneOff       bool
+	NoEmail      bool
 }
 
 // mockLinksrcInfo contains metadata about test HTTP servers so we can use it
 // to configure scraping targets for the application within a test environment.
-//
-// Fields are exported so we can use them in templates.
 type mockLinksrcInfo struct {
-	URL      string
-	Name     string
+	// Required
+	URL string
+	// Required
+	Name string
+	// Not required
 	MaxItems int
+	// Not required
+	LinkSelector string
+	// Not required
+	CaptionSelector string
+	// Not required
+	ItemSelector string
 	// The linkSelector, captionSelector, and itemSelector in a link source
 	// config. Leave blank if you would like to use valid defaults.
 	SelectorsOverride string
 }
 
-// createAppConfig writes a configuration YAML doc to the given path.
-// Use this configuration to start the e2e test environment
-func createAppConfig(path string, opts appConfigOptions) error {
-	configTemplate := `---
-email:
-    smtpServerAddress: {{ .SMTPServerAddress }}
-    fromAddress: mynewsletter@example.com
-    toAddress: recipient@example.com
-    username: myuser
-    password: password123
-    skipCertVerification: true
-link_sources:
-{{ range .LinkSources }}
-    - name: {{ .Name }}
-      url: {{ .URL }}
-	  {{- if ne .SelectorsOverride "" }}	  
-{{ .SelectorsOverride }}
-{{ else }}
-      itemSelector: "ul li"
-      captionSelector: "p"
-      linkSelector: "a"
-{{ end }}
-      maxItems: {{ .MaxItems }}
-{{ end }}
-scraping:
-    interval: {{ .PollInterval }}
-    storageDir: {{ .StorageDir }}
-`
-
-	tmpl, err := template.New("conf").Parse(configTemplate)
-
-	// This means the config template string was written incorrectly. Not
-	// an issue with the application itself.
+// createUserConfig creates a user configuration based on the provided
+// appConfigOptions. Non-required options are populated automatically using
+// defaults intended for e2e testing.
+func createUserConfig(opts appConfigOptions) (userconfig.Meta, error) {
+	if opts.LinkSources == nil || opts.SMTPServerAddress == "" || opts.PollInterval == "" || opts.StorageDir == "" {
+		return userconfig.Meta{}, errors.New("must supply all required fields in appConfigOptions")
+	}
+	v, err := time.ParseDuration(opts.PollInterval)
 	if err != nil {
-		return fmt.Errorf("couldn't parse the application config template: %v", err)
+		return userconfig.Meta{}, err
 	}
 
-	var config bytes.Buffer
+	hp := strings.Split(opts.SMTPServerAddress, ":")
 
-	err = tmpl.Execute(&config, opts)
-
-	// This is an issue with the test environment, not the application
-	if err != nil {
-		return fmt.Errorf("couldn't populate the application config template: %v", err)
+	if len(hp) != 2 {
+		return userconfig.Meta{}, errors.New("SMTPServerAddress must be in the form host:port")
 	}
 
-	cf, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("couldn't create the config file: %v", err)
+	config := userconfig.Meta{
+		EmailSettings: email.UserConfig{
+			SMTPServerHost:       hp[0],
+			SMTPServerPort:       hp[1],
+			FromAddress:          "mynewsletter@example.com",
+			ToAddress:            "recipient@example.com",
+			UserName:             "myuser",
+			Password:             "password123",
+			SkipCertVerification: true,
+		},
+		Scraping: userconfig.Scraping{
+			Interval:       v,
+			StorageDirPath: opts.StorageDir,
+			OneOff:         opts.OneOff,
+			NoEmail:        opts.NoEmail,
+		},
 	}
 
-	_, err = cf.Write(config.Bytes())
-	if err != nil {
-		return fmt.Errorf("couldn't write to the config file: %v", err)
+	config.LinkSources = make([]linksrc.Config, len(opts.LinkSources))
+	for i, ls := range opts.LinkSources {
+		if ls.URL == "" || ls.Name == "" {
+			return userconfig.Meta{}, errors.New("each mockLinksrcInfo must include a URL and Name")
+		}
+		u, err := url.Parse(ls.URL)
+		if err != nil {
+			return userconfig.Meta{}, err
+		}
+		config.LinkSources[i] = linksrc.Config{
+			Name:            ls.Name,
+			URL:             *u,
+			MaxItems:        uint(ls.MaxItems),
+			ItemSelector:    cascadia.MustCompile("ul li"),
+			CaptionSelector: cascadia.MustCompile("p"),
+			LinkSelector:    cascadia.MustCompile("a"),
+		}
+		switch {
+		case ls.CaptionSelector != "":
+			config.LinkSources[i].CaptionSelector = cascadia.MustCompile(ls.CaptionSelector)
+		case ls.ItemSelector != "":
+			config.LinkSources[i].ItemSelector = cascadia.MustCompile(ls.ItemSelector)
+		case ls.LinkSelector != "":
+			config.LinkSources[i].LinkSelector = cascadia.MustCompile(ls.LinkSelector)
+		}
 	}
 
-	return nil
+	return config, nil
 
 }

--- a/main.go
+++ b/main.go
@@ -2,15 +2,11 @@ package main
 
 import (
 	"flag"
-	"net/http"
 	"os"
 	"os/signal"
-	"sync"
 	"time"
 
-	"github.com/ptgott/one-newsletter/html"
-	"github.com/ptgott/one-newsletter/linksrc"
-	"github.com/ptgott/one-newsletter/storage"
+	"github.com/ptgott/one-newsletter/scrape"
 	"github.com/ptgott/one-newsletter/userconfig"
 
 	"github.com/rs/zerolog/log"
@@ -73,157 +69,32 @@ func main() {
 			Msg("Problem parsing your config")
 		os.Exit(1)
 	}
+	config.Scraping.OneOff = *oneOff
+	config.Scraping.NoEmail = *noEmail
+
+	checkedConfig, err := config.CheckAndSetDefaults()
+	if err != nil {
+		log.Error().
+			Err(err).
+			Msg("Problem validating your config")
+		os.Exit(1)
+	}
 
 	log.Info().Str("configPath", *configPath).Msg("successfully validated the config")
 
-	// Declare channels between the main goroutine and the scrapers
-	errCh := make(chan error) // errors to print
 	scrapeCadence := time.NewTicker(config.Scraping.Interval)
-
-	httpClient := http.Client{
-		// Determined arbitrarily. We don't want to wait forever for a request
-		// to complete, but the cadence of the newsletter means that a minute
-		// of extra waiting is probably okay.
-		Timeout: time.Duration(60) * time.Second,
+	scrapeConfig := scrape.Config{
+		TickCh:   scrapeCadence.C,
+		ErrCh:    make(chan error), // errors to print
+		OutputWr: os.Stdout,        // write to stdout if the -no-email flag is given
+		StopCh:   nil,              // since we simply exit on a SIGINT
 	}
 
-	// Start the main scraping/email sending loop
-	go func(tc <-chan time.Time, ec chan error) {
-		for {
-			// Block until the next scraping interval unless this is a one-time
-			// deal
-			if !*oneOff {
-				<-tc
-			}
-
-			// Create a new db instance per scrape so we can close the db
-			// after the scrapers are finished and ensure disk writes.
-			var db storage.KeyValue
-			if *oneOff == false {
-				db, err = storage.NewBadgerDB(
-					config.Scraping.StorageDirPath,
-					// A key inserted at one polling interval expires two intervals
-					// later, meaning that the interval after a link is collected,
-					// we can still compare it to newly collected links.
-					2*config.Scraping.Interval,
-				)
-				if err != nil {
-					log.Error().
-						Err(err).
-						Msg("problem connecting to the database")
-					continue // Maybe this was a transient error? Log it and move on.
-				}
-			} else {
-				db = &storage.NoOpDB{}
-			}
-			log.Info().Msg("set up the database connection successfully")
-			log.Info().
-				Int("count", len(config.LinkSources)).
-				Msg("launching scrapers")
-			var wg sync.WaitGroup
-			d := html.NewEmailData()
-
-			// buffer the results of the latest scrape so we can perform a diff
-			// with the previous scrape and build an email body
-			emailBuildCh := make(chan linksrc.Set, len(config.LinkSources))
-			wg.Add(len(config.LinkSources))
-			for _, ls := range config.LinkSources {
-				go func(
-					lc linksrc.Config,
-					g *sync.WaitGroup,
-					bc chan linksrc.Set,
-					ech chan error,
-				) {
-					defer g.Done()
-					// Try the scrape request only once. If we get a non-2xx
-					// response, it's probably not something we can expect to
-					// clear up after retrying.
-					r, err := httpClient.Get(lc.URL.String())
-					if err != nil {
-						ech <- err
-						return
-					}
-					defer r.Body.Close()
-					s := linksrc.NewSet(r.Body, lc, r.StatusCode)
-
-					bc <- s
-
-				}(ls, &wg, emailBuildCh, ec)
-			}
-			wg.Wait()
-			// TODO: Having the receiver close the channel is not how close()
-			// was intended to be used, but senders have no way of knowing
-			// when to close the channel, and we need to use close() in order
-			// to range over the channel below.
-			close(emailBuildCh)
-			log.Info().
-				Msg("done with one round of scraping")
-			for set := range emailBuildCh {
-				// See if any items are missing in the db. If so, store them
-				// and add them to a new email body.
-				for _, item := range set.LinkItems() {
-					// Read returns a "key not found" error if a key is not found.
-					// https://pkg.go.dev/github.com/dgraph-io/badger#Txn.Get
-					_, err := db.Read(item.Key())
-					// If the Item already exists in the database,
-					if err == nil {
-						set.RemoveLinkItem(item)
-					} else {
-						log.Info().Msg("storing a link item in the database")
-						err = db.Put(item.NewKVEntry())
-						if err != nil {
-							log.Error().
-								Err(err).
-								Msg("error saving a link item")
-							continue
-						}
-					}
-				}
-				d.Add(set)
-				log.Info().
-					Int("itemCount", set.CountLinkItems()).
-					Str("setName", set.Name).
-					Msg("added items to the email")
-			}
-
-			// Get rid of old keys just before we close
-			err = db.Cleanup()
-			if err != nil {
-				log.Error().Err(err).Msg("error cleaning up the database")
-			}
-			// Close the connection here so BadgerDB can flush to disk.
-			// Otherwise, BadgerDB has to reach its MaxTableSize before it
-			// flushes--we want to write the results of each scraping round to
-			// disk, and there's no need to keep the DB connection open while
-			// waiting for the next scrape.
-			//
-			// https://pkg.go.dev/github.com/dgraph-io/badger#readme-i-don-t-see-any-disk-writes-why
-			db.Close()
-			log.Info().Msg("closed the database to flush data to disk")
-			bod := d.GenerateBody()
-			txt := d.GenerateText()
-			log.Info().Msg("attempting to send an email")
-
-			if *noEmail {
-				os.Stdout.Write([]byte(bod))
-			} else {
-				err = config.EmailSettings.SendNewsletter([]byte(txt), []byte(bod))
-				if err != nil {
-					log.Error().Err(err).Msg("error sending an email")
-				}
-			}
-
-			// We're only doing this once, so get out of the main loop
-			if *oneOff {
-				close(errCh)
-				return
-			}
-		}
-	}(scrapeCadence.C, errCh)
+	go scrape.StartLoop(&scrapeConfig, &checkedConfig)
 
 	// At this point, the main goroutine blocks until there's an error
 	for {
-		err, ok := <-errCh
+		err, ok := <-scrapeConfig.ErrCh
 		// There's no need for the error channel anymore, so we stop
 		// looping and let the rest of the program complete.
 		if !ok {
@@ -232,4 +103,5 @@ func main() {
 			log.Error().Err(err).Msg("error gathering links to email")
 		}
 	}
+
 }

--- a/scrape/doc.go
+++ b/scrape/doc.go
@@ -1,0 +1,5 @@
+package scrape
+
+// scrape is responsible for running the main scrape/email flow. It sends
+// requests to user-configured websites, collects links, and sends the links
+// to the user in the form of an email newsletter.

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1,0 +1,225 @@
+package scrape
+
+import (
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/ptgott/one-newsletter/html"
+	"github.com/ptgott/one-newsletter/linksrc"
+	"github.com/ptgott/one-newsletter/storage"
+	"github.com/ptgott/one-newsletter/userconfig"
+	"github.com/rs/zerolog/log"
+)
+
+type Config struct {
+	// For time.Ticker ticks
+	TickCh <-chan time.Time
+	// Channel to send errors to
+	ErrCh chan error
+	// Channel for stopping the scraper
+	StopCh chan struct{}
+	// Writer for a message to display when a scrape has finished.The means
+	// of display is controlled by the caller. Intended for email text shown
+	// when the --noemail flag is used.
+	OutputWr io.Writer
+}
+
+// Run conducts a single scrape and email cycle and returns the first error
+// encountered. It reads the user config anew at the beginning of each cycle. At
+// the end of a scrape cycle, it sends an email or, depending on the config,
+// writes a plaintext version of the email message to outwr.
+func Run(outwr io.Writer, config *userconfig.Meta) error {
+
+	httpClient := http.Client{
+		// Determined arbitrarily. We don't want to wait forever for a
+		// request to complete, but the cadence of the newsletter means
+		// that a minute of extra waiting is probably okay.
+		Timeout: time.Duration(60) * time.Second,
+	}
+
+	var db storage.KeyValue
+	if config.Scraping.NoEmail || config.Scraping.OneOff {
+		db = &storage.NoOpDB{}
+	} else {
+		var err error
+		db, err = storage.NewBadgerDB(
+			config.Scraping.StorageDirPath,
+			// A key inserted at one polling
+			// interval expires two intervals
+			// later, meaning that the interval
+			// after a link is collected,
+			// we can still compare it to newly
+			// collected links.
+			time.Duration(2)*config.Scraping.Interval,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Info().Msg("set up the database connection successfully")
+	log.Info().
+		Int("count", len(config.LinkSources)).
+		Msg("launching scrapers")
+	var wg sync.WaitGroup
+	d := html.NewEmailData()
+
+	// buffer the results of the latest scrape so we can perform a diff
+	// with the previous scrape and build an email body
+	emailBuildCh := make(chan linksrc.Set, len(config.LinkSources))
+	wg.Add(len(config.LinkSources))
+	var ec chan error
+	for _, ls := range config.LinkSources {
+		go func(
+			lc linksrc.Config,
+			g *sync.WaitGroup,
+			bc chan linksrc.Set,
+			ech chan error,
+		) {
+			defer g.Done()
+			// Try the scrape request only once. If we get a non-2xx
+			// response, it's probably not something we can expect to
+			// clear up after retrying.
+			r, err := httpClient.Get(lc.URL.String())
+			if err != nil {
+				ech <- err
+				return
+			}
+			defer r.Body.Close()
+			s := linksrc.NewSet(r.Body, lc, r.StatusCode)
+
+			bc <- s
+
+		}(ls, &wg, emailBuildCh, ec)
+	}
+	wg.Wait()
+
+	// Return the first error sent to the channel
+	select {
+	case err := <-ec:
+		return err
+	default:
+	}
+	// TODO: Having the receiver close the channel is not how close()
+	// was intended to be used, but senders have no way of knowing
+	// when to close the channel, and we need to use close() in order
+	// to range over the channel below.
+	close(emailBuildCh)
+	log.Info().
+		Msg("done with one round of scraping")
+	for set := range emailBuildCh {
+		// See if any items are missing in the db. If so, store them
+		// and add them to a new email body.
+		for _, item := range set.LinkItems() {
+			// Read returns a "key not found" error if a key is not found.
+			// https://pkg.go.dev/github.com/dgraph-io/badger#Txn.Get
+			_, err := db.Read(item.Key())
+			// If the Item already exists in the database,
+			if err == nil {
+				set.RemoveLinkItem(item)
+			} else {
+				log.Info().Msg("storing a link item in the database")
+				err = db.Put(item.NewKVEntry())
+				if err != nil {
+					log.Error().
+						Err(err).
+						Msg("error saving a link item")
+					continue
+				}
+			}
+		}
+		d.Add(set)
+		log.Info().
+			Int("itemCount", set.CountLinkItems()).
+			Str("setName", set.Name).
+			Msg("added items to the email")
+	}
+
+	// Get rid of old keys just before we close
+	err := db.Cleanup()
+	if err != nil {
+		log.Error().Err(err).Msg("error cleaning up the database")
+	}
+	// Close the connection here so BadgerDB can flush to disk.
+	// Otherwise, BadgerDB has to reach its MaxTableSize before it
+	// flushes--we want to write the results of each scraping round to
+	// disk, and there's no need to keep the DB connection open while
+	// waiting for the next scrape.
+	//
+	// https://pkg.go.dev/github.com/dgraph-io/badger#readme-i-don-t-see-any-disk-writes-why
+	db.Close()
+	log.Info().Msg("closed the database to flush data to disk")
+	bod := d.GenerateBody()
+	txt := d.GenerateText()
+	log.Info().Msg("attempting to send an email")
+
+	if config.Scraping.NoEmail {
+		if outwr == nil {
+			log.Warn().Msg(
+				"a writer is unavailable for receiving the output message",
+			)
+
+		} else {
+			if _, err := outwr.Write([]byte(bod)); err != nil {
+				log.Error().Err(err).Msg("cannot write the message output")
+			}
+		}
+	} else {
+		err = config.EmailSettings.SendNewsletter([]byte(txt), []byte(bod))
+		if err != nil {
+			log.Error().Err(err).Msg("error sending an email")
+		}
+	}
+
+	// We're only doing this once, so get out of the main loop
+	if config.Scraping.OneOff {
+		return nil
+	}
+	return nil
+
+}
+
+// StartLoop begins the main sequence of scraping websites for links every
+// interval (defined by tc) with the provided config. If an s.ErrCh is provided,
+// sends any errors to it. Send a struct{} to sc to stop the scraper.
+func StartLoop(s *Config, c *userconfig.Meta) {
+
+	// The first email will be sent after the scrape interval
+	// TODO: This should send the first email immediately instead.
+	if !c.Scraping.OneOff {
+		<-s.TickCh
+	}
+
+	// Run the first scrape immediately
+	err := Run(s.OutputWr, c)
+	// Make a weak effort to send any errors encountered to the provided
+	// error channel. If there are no receivers,
+	if err != nil {
+		select {
+		case s.ErrCh <- err:
+		default:
+		}
+
+	}
+
+	// enter the main scraping/email sending loop
+	for !c.Scraping.OneOff {
+		select {
+		case <-s.StopCh:
+			return
+		case <-s.TickCh:
+			go func(io.Writer, *Config) {
+				err := Run(s.OutputWr, c)
+				if err != nil {
+					select {
+					case s.ErrCh <- err:
+					default:
+					}
+				}
+			}(s.OutputWr, s)
+		}
+
+	}
+}


### PR DESCRIPTION
This change makes tests easier to run by executing scrapes in `e2e` tests as separate goroutines, rather than as child processes. This way, tests are faster and more reliable, and we can use a debugger with them.

In the newly structured e2e tests, the scraper ingests its configuration via structs, rather than requiring an io.Reader or configuration validation. Since we don't need to perform config validation in these tests, we can run the scrapre at less than the minimum interval, meaning that tests are also faster.

More specific changes:

- In the `main` function, start a goroutine that executes the scrape/email cycle once, immediately after starting the program. Then, if the `oneOff` flag isn't set, receive from the scrape cadence ticker channel and call `runScrape` with each cycle. Move the main scraping code outside the main package. Move the main scrape loop control flow into a function.

- Add an interrupt channel arg to `scrape.StartLoop`

- Send scraper output to a channel: Previously, `scrape.Run` would, when given the `noemail` flag, write output messages directly to `os.Stdout`. This sends these messages to a channel instead so it's more straightforward to test the scraper. Tests can simply read from the channel.

- Write -no-email messages to an io.Writer: Rather than always write the output of a scrape to stdout, write to a generic io.Writer instead. This way, we can test the output of the -no-email flag without spawning a child process and capturing stdout.

- Set db path in Parse, not `main`: Moving business logic out of `main` so this is easier to test.

- Add `CheckAndSetDefaults` functions that separate config validation logic from parsing logic. This way, we can add configs to tests without parsing them from an `io.Reader`.