### PR TITLE
Change caption extraction behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,29 @@
 
 ## A bento box for your media diet
 
-One Newsletter checks online newspapers, magazines, and blogs for updates and emails you a newsletter with the latest links. You can then save these to a read-it-later service like Pocket, send them to friends, or whatever else you do with links to content. Unlike traditional RSS readers, you can limit the number of links you receive for each publication so you don't get overwhelmed. And since One Newsletter scrapes the sites you want to check, you're not limited to sites with RSS feeds.
+One Newsletter checks online newspapers, magazines, and blogs for updates and
+emails you a newsletter with the latest links. You can then save these to a
+read-it-later service like Pocket, send them to friends, or whatever else you do
+with links to content. 
+
+Unlike traditional RSS readers, you can limit the number of links you receive
+for each publication so you don't get overwhelmed. And since One Newsletter
+scrapes the sites you want to check, you're not limited to sites with RSS feeds.
 
 ## How is it deployed?
 
-One Newsletter is designed to run on low-cost VMs (e.g., the least expensive [Digital Ocean VM](https://www.digitalocean.com/pricing/#standard-droplets)). Outside of the VM, the only required infrastructure is:
+One Newsletter is designed to run on low-cost VMs (e.g., the least expensive
+[Digital Ocean VM](https://www.digitalocean.com/pricing/#standard-droplets)).
+Outside of the VM, the only required infrastructure is:
 
-- **Persistent block storage:** One Newsletter keeps track of links it has already collected by storing them on disk via BadgerDB. You need to provide the path to a storage device that One Newsletter can use for BadgerDB's data directory.
+- **Persistent block storage:** One Newsletter keeps track of links it has
+ already collected by storing them on disk via BadgerDB. You need to provide
+ the path to a storage device that One Newsletter can use for BadgerDB's data
+ directory.
 
-- **An SMTP relay server:** One Newsletter needs to connect to an SMTP server in order to send email. This can be a service like Mailgun or a local relay like Postfix if you're into that sort of thing.
+- **An SMTP relay server:** One Newsletter needs to connect to an SMTP server in
+ order to send email. This can be a service like Mailgun or a local relay like
+ Postfix if you're into that sort of thing.
 
 ## How to run it
 
@@ -22,16 +36,23 @@ onenewsletter -config path/to/config.yaml
 
 ### Link sources and link items
 
-One Newsletter works by scraping **link sources**, web pages with lists of links to other web pages. These lists of links are called **link items**, and each one is assumed to have both a link URL and a caption that describes the URL.
+One Newsletter works by scraping **link sources**, web pages with lists of links
+to other web pages. These lists of links are called **link items**, and each one
+is assumed to have both a link URL and a caption that describes the URL.
 
-You can configure One Newsletter to detect link items within a link source in two ways:
+You can configure One Newsletter to detect link items within a link source in
+two ways:
 
-- Automatically: You identify the CSS selector for the `a` elements that that contain the links you want in your newsletter, and One Newsletter will identify the best caption for each link based on its surrounding HTML.
-- Manually: You identify the CSS selector for each link item. Within each link item, you also identify the CSS selector for the caption and `a` element.
+- Automatically: You identify the CSS selector for the `a` elements that that
+ contain the links you want in your newsletter, and One Newsletter will
+ identify the best caption for each link based on its surrounding HTML.
+- Manually: You identify the CSS selector for each link item. Within each link
+ item, you also identify the CSS selector for the caption and `a` element.
 
 ### Configuration
 
-One Newsletter reads its configuration from the YAML file at the `-config` path. The file has the following structure.
+One Newsletter reads its configuration from the YAML file at the `-config` path.
+The file has the following structure.
 
 ```yaml
 # Configuration for the SMTP relay. The relay must advertise STARTTLS and
@@ -89,35 +110,77 @@ link_sources:
     # If more link items are found, One Newsletter won't extract links from
     # them.
     maxItems: 10
+    # The minimum number of words that must be in a block-level HTML element
+    # before we can add it to a link item's caption. This filters out things
+    # like bylines, tags, and other text that doesn't display well in a caption. 
+    #
+    # It's hard to predict the kind of text that a site will include
+    # within an element, so we set a pretty good default (three words) and
+    # enable users to configure this. Set it to a lower value if a link source
+    # tends to include a lot of two-word titles, for example.
+    minElementWords: 5
 ```
 
 ### Optional flags
 
-By default, One Newsletter will periodically scrape the websites of your choice, check the results against past results, and send an email containing the new links. You can alter this behavior with the following flags:
+By default, One Newsletter will periodically scrape the websites of your choice,
+check the results against past results, and send an email containing the new
+links. You can alter this behavior with the following flags:
 
-- `-oneoff`: Carry out a single scrape and send a single email. Since One Newsletter only saves the results of a scrape in order to carry out repeated checks, this flag also stops it from saving results to the database. Useful if you want to try out One Newsletter without waiting.
+- `-oneoff`: Carry out a single scrape and send a single email. Since One
+ Newsletter only saves the results of a scrape in order to carry out repeated
+ checks, this flag also stops it from saving results to the database. Useful if
+ you want to try out One Newsletter without waiting.
 
-- `-noemail`: Print an email's HTML to standard output rather than sending it. You can then redirect the HTML to a file of your choice or just read it from the terminal. Useful if you would like to run this on your local machine.
+- `-noemail`: Print an email's HTML to standard output rather than sending it.
+ You can then redirect the HTML to a file of your choice or just read it from
+ the terminal. Useful if you would like to run this on your local machine.
 
-You can use the `-oneoff` and `-noemail` flags together for a quick configuration check. One Newsletter will print the results of a scrape to your terminal without sending an email.
+You can use the `-oneoff` and `-noemail` flags together for a quick
+configuration check. One Newsletter will print the results of a scrape to your
+terminal without sending an email.
 
 ### How automatic link item detection works
 
-Automatic link item detection works from the assumption that each link sits in a chunk of automatically generated HTML, e.g., the result of server-side template rendering or client-side JavaScript components. Once you'e supplied the CSS selector for the link element, One Newsletter identifies the surrounding chunk of HTML—the link item—then extracts all possible captions within that link item. Finally, One Newsletter identifies the best possible caption within each link item and uses that for the newsletter.
+Automatic link item detection works from the assumption that each link sits in a
+chunk of automatically generated HTML, e.g., the result of server-side template
+rendering or client-side JavaScript components. We expect HTML around each link
+to have a similar structure. Once you identify a link element, we can identify
+that structure and extract captions from each repeating element.
 
-To identify the link item that surrounds each `a` element, One Newsletter traverses each `a` element's parents in the HTML element tree. It recursively considers each parent until it identifies an HTML node that is (a) repeating and (b) not identifical to itself. Each of these nodes becomes the root node in a tree that will eventually contain a link item's caption.
+To identify the link item that surrounds each `a` element, One Newsletter
+traverses each `a` element's parents in the HTML element tree. It recursively
+considers each parent until it identifies an HTML node that is (a) repeating and
+(b) not identifical to itself. Each of these nodes becomes the root node in a
+tree that will eventually contain a link item's caption.
 
-Next, One Newsletter conducts a recursive, depth-first search of each link item's child nodes for possible captions. For each child node, it extracts all of the text nodes below that child node, and keeps track of those child nodes' immediate parents.
+Next, One Newsletter conducts a recursive, depth-first search of each link
+item's child nodes for possible captions. For each child node, it extracts all
+of the text nodes below that child node, and keeps track of those child nodes'
+immediate parents.
 
-This information—the child node, its accumulated text nodes, and the nodes that the text was extracted from—becomes the basis for scoring each possible caption. The best caption is the one with the highest number of words and the lowest number of nodes. The idea here is that a link item includes a couple of elements, e.g., `p` or `div` elements, that contain the bulk of the description of a link. The more elements there are in a caption, the more likely these are to be bylines, tags, and other extraneous information.
+From there, it adds text nodes to the caption based on each text node's parent.
+If a text node's parent is a block-level node, like a paragraph or a `div`, the
+assumption is that the text is self contained. If the text in a block-level
+element doesn't end in punctuation, One Newsletter adds a period. 
 
-Descriptions often include inline elements, like the `strong` tag, to set formatting. These inline elements are ignored when calculating the score of each caption, since they are usually not involved in splitting the description into discrete parts.
+For text within inline nodes like `span`s, we assume that the text in the node
+belongs to a wider whole, and append it to any neighboring inline elements.
+
+Only block-level elements with more words than the user-configured
+`minElementWords` end up in a link item's caption. We truncate each caption at
+20 words. 
 
 ## Testing
 
-One Newsletter uses a mix of unit tests and end-to-end tests. Any new logic should be tested with unit tests unless it's not possible to do so. End-to-end tests live in the **e2e** directory. These run One Newsletter as a child process as well as an end-to-end testing process that includes separate goroutines for local HTTP and SMTP servers.
+One Newsletter uses a mix of unit tests and end-to-end tests. Any new logic
+should be tested with unit tests unless it's not possible to do so. End-to-end
+tests live in the **e2e** directory. These run One Newsletter as a child process
+as well as an end-to-end testing process that includes separate goroutines for
+local HTTP and SMTP servers.
 
-You can run all tests for One Newsletter from the project root with the following command:
+You can run all tests for One Newsletter from the project root with the
+following command:
 
 ```
 go test ./...

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,14 +15,14 @@
    classification (e.g.,
    https://www.imperva.com/blog/how-incapsula-client-classification-challenges-bots/).
 
-One example is https://aldaily.com/articles-of-note, where the first request to
-the page gets a 301 redirect containing a cookie and a `Location` header
-pointing to the same path as before. The subsequent request uses the cookie.
+   One example is https://aldaily.com/articles-of-note, where the first request
+   to the page gets a 301 redirect containing a cookie and a `Location` header
+   pointing to the same path as before. The subsequent request uses the cookie.
 
-Make the One Newsletter HTTP client more sophisticated so it passes client
-classification tests (unless it genuinely shouldn't by some commonly accepted
-standard). For example, we can set a `Jar` and `CheckRedirect` in the
-`http.Client` (https://pkg.go.dev/net/http#Client).
+   Make the One Newsletter HTTP client more sophisticated so it passes client
+   classification tests (unless it genuinely shouldn't by some commonly accepted
+   standard). For example, we can set a `Jar` and `CheckRedirect` in the
+   `http.Client` (https://pkg.go.dev/net/http#Client).
 
 1. Account for the possibility that some sites are dynamic. Maybe use a headless
    browser for all requests, rather than Go's HTTP client?
@@ -31,10 +31,11 @@ standard). For example, we can set a `Jar` and `CheckRedirect` in the
 
 1. Make it easier to test new configurations.
 
-- More helpful warnings about bad link selectors (e.g., not specific enough).
-- Add verbose logs re: where in the automatic link parsing process One
-- Newsletter failed to parse links. This would be useful for `oneoff`/`noemail`.
-- Send the first email right away rather than after the scraping interval. This
+  - More helpful warnings about bad link selectors (e.g., not specific enough).
+  - Add verbose logs re: where in the automatic link parsing process One
+  - Newsletter failed to parse links. This would be useful for
+  - `oneoff`/`noemail`.  Send the first email right away rather than after the
+  - scraping interval. This
   will make it easier to determine whether the app is running as expected.
 
 1. Include help text when the CLI is run without arguments. Also add a `help` subcommand and flag.

--- a/linksrc/autodetect.go
+++ b/linksrc/autodetect.go
@@ -48,6 +48,15 @@ var inlineTags = map[string]struct{}{
 	"wbr":    {},
 }
 
+// used for determining if a string ends with a punctuation mark
+var punctuationPattern string = `[!\.?]`
+var punctuationRe *regexp.Regexp = regexp.MustCompile(punctuationPattern + " ?$")
+
+// For catching erroneous spaces before punctuation
+var spaceBeforePunctuationRe *regexp.Regexp = regexp.MustCompile(`\s+(` + punctuationPattern + ")")
+
+var wordRe *regexp.Regexp = regexp.MustCompile(`[\w-]+`)
+
 // distanceFromRootNode returns the number of edges between html.Node n and the
 // root of the HTML document tree
 func distanceFromRootNode(n *html.Node) int {
@@ -184,12 +193,11 @@ func highestRepeatingContainers(n []*html.Node) ([]linkContainer, error) {
 
 }
 
-// textNodeScoreInfo includes all the data required to score a text node that
-// makes up part of a larger caption candidate.
-type textNodeScoreInfo struct {
+// textNodeInfo includes all the data required to extract text from an
+// `html.Node` tree.
+type textNodeInfo struct {
 	// A map where each key is the parent of a text node used to extract
-	// text for the caption. The length of this map is used to calculate
-	// the caption candidate's score. A map is used to prevent counting
+	// text for the caption. The map is used to prevent counting
 	// duplicate parent nodes.
 	nodes map[*html.Node]struct{}
 	// The text of a text node and child text nodes
@@ -198,50 +206,106 @@ type textNodeScoreInfo struct {
 	container *html.Node
 }
 
-// extractTextFromNode conducts a recursive depth-first search of n. It appends
-// text nodes to the textNodeScoreInfo c until no more child nodes remain.
-// If c is nil, begins with an empty textNodeScoreInfo.
-// No-op if n is nil. Returns the final slice of caption fragments.
-func extractTextFromNode(n *html.Node, c *textNodeScoreInfo) *textNodeScoreInfo {
+// extractTextFromNode conducts a recursive depth-first search of n, limiting
+// the search to containing node e and its children. If e is nil, it sets e to
+// n. It appends text node data to the string result until no more child nodes
+// remain, and returns the resulting string. No-op if n is nil.
+//
+// Performs the following operations when extracting text from a node:
+//
+// - Replaces divisions between block-level elements with periods.
+// - Removes block-level elements that contain fewer than m words.
+func extractTextFromNode(n *html.Node, e *html.Node, c string, m int) string {
+	var o *html.Node = e
+	if o == nil {
+		o = n
+	}
+
+	// Copy the input text to assemble the return value
+	r := c
+
 	if n == nil {
 		return c
 	}
 
-	if c == nil {
-		c = &textNodeScoreInfo{
-			nodes:     map[*html.Node]struct{}{},
-			text:      "",
-			container: n,
-		}
-	}
-
 	b := n
 	for {
-		if b.Type == html.TextNode {
-			c.text += b.Data
-			// Don't count text nodes that are children of inline tags toward the
-			// node count. These text nodes should be treated as part of a wider
-			// passage of text.
-			_, ok1 := inlineTags[b.Parent.Data]
-			// Make sure we haven't counted this parent before
-			_, ok2 := c.nodes[b.Parent]
-			if !ok1 && !ok2 {
-				c.nodes[b.Parent] = struct{}{}
+		// To gather the text from this element and its children
+		bc := ""
+		if b.Type == html.TextNode && len(b.Data) > 0 {
+
+			// Replace newlines and long series of spaces with
+			// single spaces.
+			x := regexp.MustCompile("(\\s{2,}|\\n|\\t)")
+			d := x.ReplaceAllString(b.Data, " ")
+
+			// Remove non-displaying Unicode characters by appending
+			// compliant characters to a new string.
+			var txt string
+			for _, e := range d {
+				if (e >= ' ' && e < '\u007F') || e > '\u00A0' {
+					txt += string(e)
+				}
+			}
+
+			// Since we add a space to the right of each text node
+			// if it's missing one, prevent double spaces by
+			// removing the leftmost space.
+			txt = strings.TrimLeft(txt, " \t\n")
+
+			// Separate the content of this text node from the
+			// content of the next one. If this ends up being the
+			// final text node, we'll trim the space later.
+			if len(d) > 0 && d[len(d)-1] != ' ' {
+				txt += " "
+			}
+			bc += txt
+
+		}
+		// Add text from the element's children
+		if b.FirstChild != nil {
+			bc = extractTextFromNode(b.FirstChild, o, bc, m)
+		}
+
+		// The node is a block-level element with text.
+		if _, inline := inlineTags[b.Data]; b.Type == html.ElementNode &&
+			!inline &&
+			strings.Trim(bc, " ") != "" {
+
+			// The block-level element has fewer than three words,
+			// so ignore it.
+			if len(wordRe.FindAllString(bc, -1)) <= m {
+				goto nextElement
+			}
+
+			// The text doesn't doesn't end in punctuation (but not empty
+			// space), so add a period. We have already extracted text from
+			// all of the element's children and their siblings, so we know
+			// none of the children has provided punctuation.
+			if !punctuationRe.MatchString(bc) {
+
+				// Trim the caption segment in case we have a stray space
+				// before the period.
+				bc = strings.TrimRight(bc, " ") + ". "
+
 			}
 		}
-		if b.FirstChild != nil {
-			c = extractTextFromNode(b.FirstChild, c)
-		}
+
+		// We've processed all text for the element and its children, so
+		// add the text to the accumulator string.
+		r += bc
+
+	nextElement:
 		// If this is the highest node we want to consider, don't check its
 		// sibling
-		if b != c.container && b.NextSibling != nil {
+		if b != o && b.NextSibling != nil {
 			b = b.NextSibling
 			continue
 		}
 		break
 	}
 
-	return c
+	return r
 
 }
 
@@ -257,71 +321,42 @@ type captionCandidate struct {
 	score float32
 }
 
-// extractCaptionCandidate returns the captionCandidate for a given Node, i.e.,
-// the text extracted from all of the text nodes within the Node, as well as
-// the number of nodes required to perform the extraction.
-func extractCaptionCandidate(n *html.Node) captionCandidate {
-	c := extractTextFromNode(n, nil)
-
-	w := regexp.MustCompile("\\b{2}")
-	x := regexp.MustCompile("\\s{2,}|\\n")
-	c.text = strings.Trim(x.ReplaceAllString(c.text, " "), " ")
-
-	var txt string
-
-	// Remove non-displaying Unicode characters
-	for _, e := range c.text {
-		if (e >= ' ' && e < '\u007F') || e > '\u00A0' {
-			txt += string(e)
-		}
-	}
-
-	var cc captionCandidate
-	cc.text = txt
-	var r int
-
-	// Avoid dividing by zero when we calculate the score
-	if len(c.nodes) == 0 {
-		r = 1
-	} else {
-		r = len(c.nodes)
-	}
-
-	cc.nodes = r
-	cc.score = float32(len(w.FindAllString(cc.text, -1))) / float32(r)
-
-	return cc
-
-}
-
-// findBestCaptionFromFirstLevelChildren traverses the first-level children of
-// Node n, extracts a possible caption from each, and compares these captions to
-// the current best caption. It runs recursively and depth first, and returns the
-// best caption candidate it finds.
-func findBestCaptionFromFirstLevelChildren(n *html.Node, current captionCandidate) captionCandidate {
-	var best captionCandidate = current
-	for c := n.FirstChild; c != nil; c = c.NextSibling {
-		p := extractCaptionCandidate(c)
-		if p.score > best.score {
-			best = p
-		}
-		best = findBestCaptionFromFirstLevelChildren(c, best)
-	}
-	return best
-}
-
 // extractCaptionFromContainer finds the best caption from the children of n
-// and returns it as a string.
-func extractCaptionFromContainer(n *html.Node) (string, error) {
+// and returns it as a string. Within each HTML node, it performs the following
+// operations:
+//
+// - If the node is a block-level element with fewer than m words, ignores the
+//   node's text.
+// - Ensures that block-level text nodes end in punctuation.
+//
+// After extracting text from child nodes, extractCaptionFromContainer:
+//
+// - Truncates the caption at 20 words.
+// - Ensures that there is no space before a punctuation mark.
+// - Trims whitespace on either side of the caption.
+func extractCaptionFromContainer(n *html.Node, m int) (string, error) {
 	if n == nil {
 		return "", errors.New("cannot extract a caption from a nonexistent container")
 	}
 
-	var best captionCandidate = extractCaptionCandidate(n)
+	c := extractTextFromNode(n, nil, "", m)
 
-	best = findBestCaptionFromFirstLevelChildren(n, best)
+	// Truncate at 20 words
+	wi := wordRe.FindAllStringIndex(c, -1)
+	if len(wi) > 20 {
+		c = strings.TrimRight(c[:wi[20][0]], " ") + "..."
+	}
 
-	return best.text, nil
+	// Remove spaces before punctuation. We may have added these erroneously
+	// while appending text nodes. We need to do this here because we don't
+	// have a way to store text nodes temporarily and peek ahead.
+	c = spaceBeforePunctuationRe.ReplaceAllString(c, "$1")
+
+	// Now that we've assembled a caption string, remove any
+	// leading/trailing whitespace.
+	c = strings.Trim(c, " \n\t")
+
+	return c, nil
 
 }
 
@@ -362,7 +397,7 @@ func autoDetectLinkItems(n *html.Node, conf Config) (map[string]LinkItem, []stri
 
 	for _, c := range h {
 
-		t, err := extractCaptionFromContainer(c.container)
+		t, err := extractCaptionFromContainer(c.container, conf.ShortElementFilter)
 		if err != nil {
 			s = append(s, err.Error())
 			continue

--- a/linksrc/set_test.go
+++ b/linksrc/set_test.go
@@ -45,11 +45,12 @@ func TestNewSet(t *testing.T) {
 			name: "canonical/intended case",
 			html: mustReadFile(path.Join("testdata", "straightforward.html"), t),
 			conf: Config{
-				Name:            "My Cool Publication",
-				URL:             mustParseURL("http://www.example.com"),
-				ItemSelector:    css.MustCompile("body div#mostRead ol li"),
-				CaptionSelector: css.MustCompile("div a.itemName"),
-				LinkSelector:    css.MustCompile("div a.itemName"),
+				Name:               "My Cool Publication",
+				URL:                mustParseURL("http://www.example.com"),
+				ItemSelector:       css.MustCompile("body div#mostRead ol li"),
+				CaptionSelector:    css.MustCompile("div a.itemName"),
+				LinkSelector:       css.MustCompile("div a.itemName"),
+				ShortElementFilter: 3,
 			},
 			want: Set{
 				Name: "My Cool Publication",
@@ -73,11 +74,12 @@ func TestNewSet(t *testing.T) {
 			name: "canonical/intended case with relative link URLs",
 			html: mustReadFile(path.Join("testdata", "straightforward-relative-links.html"), t),
 			conf: Config{
-				Name:            "My Cool Publication",
-				URL:             mustParseURL("http://www.example.com"),
-				ItemSelector:    css.MustCompile("body div#mostRead ol li"),
-				CaptionSelector: css.MustCompile("a.itemName"),
-				LinkSelector:    css.MustCompile("a"),
+				Name:               "My Cool Publication",
+				URL:                mustParseURL("http://www.example.com"),
+				ItemSelector:       css.MustCompile("body div#mostRead ol li"),
+				CaptionSelector:    css.MustCompile("a.itemName"),
+				LinkSelector:       css.MustCompile("a"),
+				ShortElementFilter: 3,
 			},
 			want: Set{
 				Name: "My Cool Publication",
@@ -101,9 +103,10 @@ func TestNewSet(t *testing.T) {
 			name: "canonical/intended case with only a link selector",
 			html: mustReadFile(path.Join("testdata", "straightforward.html"), t),
 			conf: Config{
-				Name:         "My Cool Publication",
-				URL:          mustParseURL("http://www.example.com"),
-				LinkSelector: css.MustCompile("a"),
+				Name:               "My Cool Publication",
+				URL:                mustParseURL("http://www.example.com"),
+				LinkSelector:       css.MustCompile("a"),
+				ShortElementFilter: 3,
 			},
 			want: Set{
 				Name: "My Cool Publication",
@@ -127,9 +130,10 @@ func TestNewSet(t *testing.T) {
 			name: "canonical/intended case with relative link URLs and only a link selector",
 			html: mustReadFile(path.Join("testdata", "straightforward-relative-links.html"), t),
 			conf: Config{
-				Name:         "My Cool Publication",
-				URL:          mustParseURL("http://www.example.com"),
-				LinkSelector: css.MustCompile("a"),
+				Name:               "My Cool Publication",
+				URL:                mustParseURL("http://www.example.com"),
+				LinkSelector:       css.MustCompile("a"),
+				ShortElementFilter: 3,
 			},
 			want: Set{
 				Name: "My Cool Publication",
@@ -242,21 +246,8 @@ func TestNewSet(t *testing.T) {
 				LinkSelector:    css.MustCompile("a"),
 			},
 			want: Set{
-				Name: "My Cool Publication",
-				items: map[string]LinkItem{
-					"http://www.example.com/stories/hot-take": {
-						LinkURL: "http://www.example.com/stories/hot-take",
-						Caption: "",
-					},
-					"http://www.example.com/stories/stuff-happened": {
-						LinkURL: "http://www.example.com/stories/stuff-happened",
-						Caption: "",
-					},
-					"http://www.example.com/storiesreally-true": {
-						LinkURL: "http://www.example.com/storiesreally-true",
-						Caption: "",
-					},
-				},
+				Name:  "My Cool Publication",
+				items: map[string]LinkItem{},
 			},
 		},
 		{
@@ -320,25 +311,26 @@ func TestNewSet(t *testing.T) {
 			name: "autodetect: ny magazine intelligencer",
 			html: mustReadFile(path.Join("testdata", "intelligencer-feed.html"), t),
 			conf: Config{
-				Name:         "Intelligencer",
-				URL:          mustParseURL("http://www.example.com"),
-				LinkSelector: css.MustCompile("a.feed-item.article"),
-				MaxItems:     3,
+				Name:               "Intelligencer",
+				URL:                mustParseURL("http://www.example.com"),
+				LinkSelector:       css.MustCompile("a.feed-item.article"),
+				MaxItems:           3,
+				ShortElementFilter: 3,
 			},
 			want: Set{
 				Name: "Intelligencer",
 				items: map[string]LinkItem{
 					"http://www.example.com/intelligencer/2022/04/subway-shooting-proved-regular-new-yorkers-fight-crime-too.html": {
 						LinkURL: "http://www.example.com/intelligencer/2022/04/subway-shooting-proved-regular-new-yorkers-fight-crime-too.html",
-						Caption: "Mayor Adams needs to realize that cops aren’t the only crimefighters, as average New Yorkers proved during the hunt for the subway shooter.",
+						Caption: "Regular New Yorkers Fight Crime, Too. Mayor Adams needs to realize that cops aren’t the only crimefighters, as average...",
 					},
 					"http://www.example.com/intelligencer/2022/04/what-happened-to-paxlovid-the-covid-19-wonder-drug.html": {
 						LinkURL: "http://www.example.com/intelligencer/2022/04/what-happened-to-paxlovid-the-covid-19-wonder-drug.html",
-						Caption: "The much-hyped antiviral arrived too late for the Omicron wave, but it remains a powerful — and potentially versatile — weapon against COVID-19.",
+						Caption: "What Happened to Paxlovid, the COVID Wonder Drug? The much-hyped antiviral arrived too late for the Omicron wave, but it...",
 					},
 					"http://www.example.com/intelligencer/article/what-republicans-mean-rigged-election.html": {
 						LinkURL: "http://www.example.com/intelligencer/article/what-republicans-mean-rigged-election.html",
-						Caption: "Republicans claim Democrats are breaking election and voter laws. But deep down the complaint may be that perfectly legal votes are bad for the GOP.",
+						Caption: "What Is a ‘Rigged’ Election Anyway? Republicans claim Democrats are breaking election and voter laws. But deep down the complaint...",
 					},
 				},
 				messages: nil,
@@ -358,18 +350,43 @@ func TestNewSet(t *testing.T) {
 				items: map[string]LinkItem{
 					"https://www.example.com/2022/05/05/books/carlo-rovelli-physicist-book.html": {
 						LinkURL: "https://www.example.com/2022/05/05/books/carlo-rovelli-physicist-book.html",
-						Caption: "May 6, 2022 | “Capital ‘T,’ ‘the Truth’ … I don’t think it’s interesting,” says Carlo Rovelli. “The interesting thing is the small ‘t’...more»",
+						Caption: "May 6, 2022 | “Capital ‘T,’ ‘the Truth’ … I don’t think it’s interesting,” says Carlo Rovelli. “The interesting thing...",
 					},
 					"https://www.example.com/archive/great-debates/weighing-evidence": {
 						LinkURL: "https://www.example.com/archive/great-debates/weighing-evidence",
-						Caption: "May 5, 2022 | Science advances not by convincing skeptics they are wrong, but by waiting until those skeptics die. Consider Galileo...more»",
+						Caption: "May 5, 2022 | Science advances not by convincing skeptics they are wrong, but by waiting until those skeptics die. Consider...",
 					},
 					"https://www.example.com/latest/miloszs-magic-mountain-neumeyer": {
 						LinkURL: "https://www.example.com/latest/miloszs-magic-mountain-neumeyer",
-						Caption: "May 4, 2022 | It's been said that every intellectual forced to emigrate is mutilated. So it was with Czeslaw Miloszin California...more»",
+						Caption: "May 4, 2022 | It's been said that every intellectual forced to emigrate is mutilated. So it was with Czeslaw...",
 					},
 				},
 				messages: nil},
+		},
+		{
+			name: "news source with a lot of short block-level HTMl text",
+			html: mustReadFile(path.Join("testdata", "music-reviews.html"), t),
+			conf: Config{
+				Name:               "Music Review Site",
+				URL:                mustParseURL("https://www.example.com"),
+				LinkSelector:       css.MustCompile("div.review a.review__link"),
+				ShortElementFilter: 0,
+			},
+			want: Set{
+				Name: "Music Review Site",
+				items: map[string]LinkItem{
+					"https://www.example.com/reviews/albums/100-gecs-snake-eyes-ep/": LinkItem{
+						LinkURL: "https://www.example.com/reviews/albums/100-gecs-snake-eyes-ep/",
+						Caption: "100 gecs. Snake Eyes EP. Experimental. Electronic. by: Joshua Minsoo Kim. December 12 2022.",
+					},
+					"https://www.example.com/reviews/albums/brakence-hypochondriac/": LinkItem{
+						LinkURL: "https://www.example.com/reviews/albums/brakence-hypochondriac/",
+						Caption: "brakence. hypochondriac. Rock. by: H.D. Angel. December 15 2022.",
+					},
+				},
+				messages: nil,
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -431,6 +448,73 @@ func TestNewSetWithMaxLinks(t *testing.T) {
 			got := NewSet(mustReadFile(path.Join("testdata", "straightforward.html"), t), tt.conf, tt.code)
 			if len(got.items) != tt.wantSetLength {
 				t.Errorf("wanted a Set with %v links but got %v", tt.wantSetLength, got)
+			}
+		})
+	}
+}
+
+func TestSetClean(t *testing.T) {
+	testCases := []struct {
+		description string
+		input       Set
+		expected    Set
+	}{
+		{
+			description: "already clean set",
+			input: Set{
+				Name: "My Site 1",
+				items: map[string]LinkItem{
+					"item1": LinkItem{
+						LinkURL: "https://www.example.com/article1",
+						Caption: "This is my caption.",
+					},
+				},
+				messages: []string{},
+			},
+			expected: Set{
+				Name: "My Site 1",
+				items: map[string]LinkItem{
+					"item1": LinkItem{
+						LinkURL: "https://www.example.com/article1",
+						Caption: "This is my caption.",
+					},
+				},
+				messages: []string{},
+			},
+		},
+		{
+			description: "whitespace-only caption",
+			input: Set{
+				Name: "My Site 1",
+				items: map[string]LinkItem{
+					"item1": LinkItem{
+						LinkURL: "https://www.example.com/article1",
+						Caption: " ",
+					},
+					"item2": LinkItem{
+						LinkURL: "https://www.example.com/article2",
+						Caption: "Something happened today.",
+					},
+				},
+				messages: []string{},
+			},
+			expected: Set{
+				Name: "My Site 1",
+				items: map[string]LinkItem{"item2": LinkItem{
+					LinkURL: "https://www.example.com/article2",
+					Caption: "Something happened today.",
+				},
+				},
+				messages: []string{},
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.description, func(t *testing.T) {
+			actual := cleanSet(c.input)
+			if !reflect.DeepEqual(actual, c.expected) {
+				t.Fatalf("%v: expected %+v but got %+v", c.description, c.expected, actual)
 			}
 		})
 	}

--- a/linksrc/testdata/music-reviews.html
+++ b/linksrc/testdata/music-reviews.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>This is my website</title>
+  </head>
+  <body>
+    <div id="site-content">
+      <div id="reviews" class="reviews-page">
+        <div id="reviews-nav" class="section-nav">
+          <div class="container-fluid">
+            <div class="border-container clearfix">
+              <nav class="latest-navigation section-nav__menu">
+                <li class="mobile-toggle"></li>
+              </nav>
+              <div class="filters">
+                <div class="genre-menu"></div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="reviews-page__contents">
+          <div class="infinite-container">
+            <div class="clearfix">
+              <div class="review-collection-fragment">
+                <h1 class="page-title"><span>Latest Reviews</span></h1>
+                <div class="container-fluid">
+                  <div class="fragment-list">
+                    <div class="review">
+                      <a
+                        href="/reviews/albums/100-gecs-snake-eyes-ep/"
+                        class="review__link"
+                        data-uri="df82b5ad71811e6bf1871c759145ee0c"
+                        ><div class="review__artwork artwork">
+                          <div class="">
+                            <img
+                              src="https://media.example.com/photos/638a00f263c337bba89ac1fc/1:1/w_320/100-gecs-Snake-Eyes.jpg"
+                              alt="100 gecs: Snake Eyes EP"
+                            />
+                          </div>
+                        </div>
+                        <div class="review__title">
+                          <ul class="artist-list review__title-artist">
+                            <li>100 gecs</li>
+                          </ul>
+                          <h2 class="review__title-album">
+                            <em>Snake Eyes</em> EP
+                          </h2>
+                        </div></a
+                      >
+                      <div class="review__meta">
+                        <ul
+                          class="genre-list genre-list--inline review__genre-list"
+                        >
+                          <li class="genre-list__item">
+                            <a
+                              href="/reviews/albums/?genre=experimental"
+                              class="genre-list__link"
+                              data-uri="cd34d605b291aac3e7fc2b117ecd741b"
+                              >Experimental</a
+                            >
+                          </li>
+                          <li class="genre-list__item">
+                            <a
+                              href="/reviews/albums/?genre=electronic"
+                              class="genre-list__link"
+                              data-uri="f706615fb53699abd4b42139e468f344"
+                              >Electronic</a
+                            >
+                          </li>
+                        </ul>
+                        <ul class="authors">
+                          <li>
+                            <a
+                              href="/staff/joshuaminsookim/"
+                              class="linked display-name display-name--linked"
+                              data-uri="59332768be1b3d7798b1ec6d3e4addec"
+                              ><span class="by">by: </span>Joshua Minsoo Kim</a
+                            >
+                          </li>
+                        </ul>
+                        <time
+                          class="pub-date"
+                          datetime="2022-12-12T05:01:00"
+                          title="Mon Dec 12 2022 00:01:00 GMT-0500 (Eastern Standard Time)"
+                          >December 12 2022</time
+                        >
+                      </div>
+                    </div>
+                    <div class="review">
+                      <a
+                        href="/reviews/albums/brakence-hypochondriac/"
+                        class="review__link"
+                        data-uri="197f6a8298799cf5b3dfdbd7b659a78e"
+                        ><div class="review__artwork artwork">
+                          <div class="">
+                            <img
+                              src="https://media.example.com/photos/6390cc1e12b41513f51f1700/1:1/w_320/Brakence-%20hypochondriac.jpeg"
+                              alt="Brakence:
+							     Hypochondriac"
+                            />
+                          </div>
+                        </div>
+                        <div class="review__title">
+                          <ul class="artist-list review__title-artist">
+                            <li>brakence</li>
+                          </ul>
+                          <h2 class="review__title-album">
+                            <em>hypochondriac</em>
+                          </h2>
+                        </div></a
+                      >
+                      <div class="review__meta">
+                        <ul
+                          class="genre-list genre-list--inline review__genre-list"
+                        >
+                          <li class="genre-list__item">
+                            <a
+                              href="/reviews/albums/?genre=rock"
+                              class="genre-list__link"
+                              data-uri="eb92055893bfd07166d91acb24a8229f"
+                              >Rock</a
+                            >
+                          </li>
+                        </ul>
+                        <ul class="authors">
+                          <li>
+                            <a
+                              href="/staff/h-d-angel/"
+                              class="linked display-name display-name--linked"
+                              data-uri="7bc80a58b676ced499aa2c54efce0fe3"
+                              ><span class="by">by: </span>H.D. Angel</a
+                            >
+                          </li>
+                        </ul>
+                        <time
+                          class="pub-date"
+                          datetime="2022-12-15T05:01:00"
+                          title="Thu,
+															     				15
+															     				Dec
+															     				2022
+															     				05:01:00
+																			GMT"
+                          >December 15 2022</time
+                        >
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="scroll-boundary"></div>
+          </div>
+        </div>
+      </div>
+      <div></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Currently, One Newsletter extracts captions by finding the block-level element with the longest combined text nodes. The intention here was to pick the most descriptive text for a link item without including less helpful elements like bylines and tags.

However, this approach has a drawback that can make a caption incomprehensible: some short block-level elements are necessary to put longer ones in context. An example of this is when an article's headline, which the current approach often omits, introduces names that the longest sentence in the caption refers to.

Another example is when the text in a link item does not use complete sentences, so the role for the text nodes that make it into the caption often differ: sometimes a byline goes missing, sometimes a title does, etc.

This change uses the first 20 words of a link item's text for a caption. To remove meaningless text, it removes all block-level text nodes with word lengths that fall below a user-defined threshold, which defaults to
3. If a caption has more than 20 usable words, One Newsletter truncates the caption with an elipsis. One Newsletter adds a period to separate text nodes from different block-level elements.

This change also skips saving or sending a link item when it includes an empty caption.