### PR TITLE
Implement URL-only link sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,84 +40,129 @@ One Newsletter works by scraping **link sources**, web pages with lists of links
 to other web pages. These lists of links are called **link items**, and each one
 is assumed to have both a link URL and a caption that describes the URL.
 
-You can configure One Newsletter to detect link items within a link source in
-two ways:
-
-- Automatically: You identify the CSS selector for the `a` elements that that
- contain the links you want in your newsletter, and One Newsletter will
- identify the best caption for each link based on its surrounding HTML.
-- Manually: You identify the CSS selector for each link item. Within each link
- item, you also identify the CSS selector for the caption and `a` element.
-
 ### Configuration
 
 One Newsletter reads its configuration from the YAML file at the `-config` path.
 The file has the following structure.
 
+`email` configures the SMTP relay. The relay must advertise STARTTLS and AUTH.
+One Newsletter negotiates a TLS connection and uses your username and pasword to
+log in. Mutual TLS is currently not supported.
+
 ```yaml
-# Configuration for the SMTP relay. The relay must advertise STARTTLS and
-# AUTH. One Newsletter negotiates a TLS connection and uses your username
-# and pasword to log in. Mutual TLS is currently not supported.
 email:
   smtpServerAddress: smtp://0.0.0.0:123
   fromAddress: mynewsletter@example.com
   toAddress: recipient@example.com
   username: MyUser123
   password: 123456-A_BCDE
+```
 
+`scraping` configures the scraper.
+
+The `interval` field configures the way One Newsletter scrapes websites for
+links. You must provide the interval at which One Newsletter checks for updates
+and sends the newsletter, using a [Go duration
+string](https://pkg.go.dev/time#ParseDuration) like `5000ms`, `5s`, `10m`, or
+`24h`. To help prevent abuse, the minimum polling interval is `5s`. (Nothing is
+stopping you from compiling One Newsletter with a lower interval, but please
+don't be a jerk.)
+
+`storageDir` is a path to a directory where One Newsletter stores its state. One
+Newsletter keeps track of URLs it has already included in the newsletter so you
+don't get repeat content. It stores URLs from the last two polling intervals.
+
+```yaml
 scraping:
-  # The polling interval section configures the way One Newsletter scrapes
-  # websites for links.
-  # You must provide the interval at which One Newsletter checks for udpates and
-  # sends the newsletter, using a format like 5000ms, 5s, 10m, or 24h. To help
-  # prevent abuse, the minimum polling interval is 5s.
   interval: 168h # every seven days
-
-  # The storage section tells OneNewsletter how to store information abouts links
-  # it has already collected. "storageDir" is a path to a directory in which
   storageDir: ./tempTestDir3012705204
+```
 
-# This section tells One Newsletter how to scrape websites for links. One
-# Newsletter tracks these as "link sources." The assumption is that each
-# link source includes a menu of links (e.g., a "Most Read" list), and
-# One Newsletter scrapes these menus for updates.
-#
-# To enable automatic link item detection, you only need to supply the name,
-# URL, and linkSelector for each link source.
-#
-# To enable manual link item detection, you need to supply the name, URL,
-# itemSelector, captionSelector, and linkSelector for each link source.
-#
-# The following example tracks a site with a link menu that has the structure,
-# <ul>
-#   <li>
-#     <p>Here is a caption</p>
-#     <p>You can find more information<a href="/cool-story">here</a>.
-#   <li>
-#   <li>
-#     <p>Here is another caption</p>
-#     <p>You can find more information<a href="/cool-story2">here</a>.
-#   <li>
-# </ul>
+The `link_sources` section tells One Newsletter how to scrape websites for
+links. One Newsletter tracks these as **link sources**. Each link source
+includes a menu of links (e.g., a "Most Read" list), and One Newsletter scrapes
+these menus for updates by examining the structure of its **link items**, i.e.,
+a link and its surrounding HTML.
+
+You can instruct One Newsletter to scrape links at three levels of specificity,
+depending on how much you can tolerate unexpected results and you want to dig
+into a website's CSS:
+
+|Level|What you provide|What One Newsletter does|
+|---|---|---|
+|Fully automatic|The URL of a page|Identifies groups of link items and extracts captions based on the structure of each link item.|
+|Automatic caption detection|The URL of a page and the CSS selector of a link within a given item (e.g., `ul li a`)|Extracts captions based on the structure of the identified links.|
+|Fully manual|The URL of a page, the CSS selector of a link item, the CSS selector of a link within the item, and the CSS selector of a caption within the item.|Locates link items, links, and captions based on the provided information.|
+
+A minimal link source configuration looks like this:
+
+```yaml
 link_sources:
-  - name: site-38911
+  - name: site-1
+    url: https://www.example.com
+  - name: site-2
+    url: https://www.example.com
+```
+
+Or to extract captions automatically but manually configure a link selector:
+
+```yaml
+link_sources:
+  - name: site-1
+    url: https://www.example.com
+    linkSelector: "div#links article a"
+```
+
+Here is an example of a fully manual configuration. Let's say you want to follow
+a website containing a menu of links that has the structure:
+
+```html
+<ul>
+  <li>
+    <p>Here is a caption</p>
+    <p>You can find more information<a href="/cool-story">here</a>.
+  <li>
+  <li>
+    <p>Here is another caption</p>
+    <p>You can find more information<a href="/cool-story2">here</a>.
+  <li>
+</ul>
+```
+
+You can add this configuration:
+
+```yaml
+link_sources:
+  - name: site-1
     url: https://www.example.com
     itemSelector: "ul li"
     captionSelector: "p"
     linkSelector: "a"
-    # Maximum number of link items to include in an email for a publication.
-    # The default is 5. If this is 0, One Newsletter will disregard it.
-    # If more link items are found, One Newsletter won't extract links from
-    # them.
-    maxItems: 10
-    # The minimum number of words that must be in a block-level HTML element
-    # before we can add it to a link item's caption. This filters out things
-    # like bylines, tags, and other text that doesn't display well in a caption. 
-    #
-    # It's hard to predict the kind of text that a site will include
-    # within an element, so we set a pretty good default (three words) and
-    # enable users to configure this. Set it to a lower value if a link source
-    # tends to include a lot of two-word titles, for example.
+```
+
+You can fine-tune the way One Newsletter includes links in emails.
+
+`maxItems` specifies the maximum number of link items to include in an email for
+a link source. The default is 5. If this is 0, One Newsletter will disregard it.
+If more link items are found, One Newsletter won't extract links from them.
+
+`minElementWords` is the minimum number of words that must be in a block-level
+HTML element before we can add it to a link item's caption. This filters out
+things like bylines, tags, and other text that doesn't display well in a
+caption. 
+
+It's hard to predict the kind of text that a site will include within an
+element, so we set a pretty good default (three words) and enable users to
+configure this. Set it to a lower value if a link source tends to include a lot
+of two-word titles, for example.
+
+Here is an example of a link source configuration with these fields:
+
+```yaml
+link_sources:
+  - name: site-1
+    url: https://www.example.com
+    maxItems: 3
     minElementWords: 5
 ```
 
@@ -154,10 +199,9 @@ considers each parent until it identifies an HTML node that is (a) repeating and
 (b) not identifical to itself. Each of these nodes becomes the root node in a
 tree that will eventually contain a link item's caption.
 
-Next, One Newsletter conducts a recursive, depth-first search of each link
-item's child nodes for possible captions. For each child node, it extracts all
-of the text nodes below that child node, and keeps track of those child nodes'
-immediate parents.
+Next, One Newsletter searches each link item's child nodes for possible
+captions. For each child node, it extracts all of the text nodes below that
+child node, and keeps track of those child nodes' immediate parents.
 
 From there, it adds text nodes to the caption based on each text node's parent.
 If a text node's parent is a block-level node, like a paragraph or a `div`, the

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/flashmob/go-guerrilla v1.6.1/go.mod h1:ZT9TRggRsSY4ZVndoyx8TRUxi3tM/n
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/go-delve/delve v1.5.0 h1:gQsRvFdR0BGk19NROQZsAv6iG4w5QIZoJlxJeEUBb0c=
 github.com/go-delve/delve v1.5.0/go.mod h1:c6b3a1Gry6x8a4LGCe/CWzrocrfaHvkUxCj3k4bvSUQ=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
 github.com/go-fonts/latin-modern v0.2.0/go.mod h1:rQVLdDMK+mK1xscDwsqM5J8U2jrRa3T0ecnM9pNujks=

--- a/linksrc/config.go
+++ b/linksrc/config.go
@@ -68,10 +68,11 @@ func (c *Config) CheckAndSetDefaults() (Config, error) {
 	}
 
 	// Check for the presence of an itemSelector, captionSelector, and
-	// linkSelector. If there's only a linkSelector, we enable link auto-
-	// detection. Otherwise, we need all three fields.
-	if c.LinkSelector == nil {
-		return Config{}, errors.New("you must provide a link selector")
+	// linkSelector. If there's only a linkSelector, we enable caption auto-
+	// detection. If there is no link selector, we auto-detect links.
+	// Otherwise, we need all three fields.
+	if c.LinkSelector == nil && (c.ItemSelector != nil || c.CaptionSelector != nil) {
+		return Config{}, errors.New("to detect captions manually, you must provide a link selector, item selector, and caption selector")
 	}
 
 	if (c.ItemSelector == nil && c.CaptionSelector != nil) ||

--- a/linksrc/config_test.go
+++ b/linksrc/config_test.go
@@ -149,6 +149,15 @@ minElementWords: 0
 			expectedShortElementFilter: 0,
 			expectErr:                  false,
 		},
+		{
+			description: "minElementWords of three, URL-only mode",
+			config: `name: site-38911
+url: http://127.0.0.1:38911
+minElementWords: 3
+`,
+			expectedShortElementFilter: 3,
+			expectErr:                  false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -335,7 +344,14 @@ func TestCheckAndSetDefaults(t *testing.T) {
 			},
 		},
 		{
-			description:        "no link selector",
+			description: "valid case with no link selector",
+			input: Config{
+				Name: "site-38911",
+				URL:  mustParseURL("http://127.0.0.1:38911"),
+			},
+		},
+		{
+			description:        "item selector and caption selector but no link selector",
 			expectErrSubstring: "link selector",
 			input: Config{
 				Name:            "site-38911",

--- a/linksrc/testdata/straightforward_multiple_container_types.html
+++ b/linksrc/testdata/straightforward_multiple_container_types.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>This is my website</title>
+  </head>
+  <body>
+    <h1>This is my cool website</h1>
+    <div id="mostRead">
+      <h2>Most read posts today</h2>
+      <ol>
+        <li>
+          <img src="img1.png" alt="A cool image" />
+          <div class="byline">By <strong>the staff</strong></div>
+          <div class="itemHolder">
+            <a href="http://www.example.com/stories/hot-take" class="itemName"
+              >This is a hot take!</a
+            >
+          </div>
+        </li>
+        <li>
+          <img src="img2.png" alt="This is an image" />
+          <div class="byline">By <strong>the staff</strong></div>
+          <div class="itemHolder">
+            <a
+              href="http://www.example.com/stories/stuff-happened"
+              class="itemName"
+              >Stuff happened today, yikes.</a
+            >
+          </div>
+        </li>
+      </ol>
+      <h2>Highlights you might be interested in</h2>
+      <div class="highlight-container">
+	  <div class="highlight">
+	      <p>This is a headline for an article.</p>
+	      <p><a href="http://www.example.com/stories/cool-headline">Click
+		  here.</a></p>
+	  </div>
+	  <div class="highlight">
+	      <p>This is a headline for another article.</p>
+	      <p><a href="http://www.example.com/stories/cool-story">Click
+		  here.</a></p>
+	  </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ptgott/one-newsletter/scrape"
 	"github.com/ptgott/one-newsletter/userconfig"
 
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -45,7 +46,21 @@ func main() {
 		false,
 		"run the scrapers once and (unless -noemail is present) send one email",
 	)
+	level := flag.String(
+		"level",
+		"info",
+		`log level: "info", "debug", or "warn"`,
+	)
 	flag.Parse()
+
+	switch *level {
+	case "debug":
+		log.Logger = log.Logger.Level(zerolog.DebugLevel)
+	case "warn":
+		log.Logger = log.Logger.Level(zerolog.WarnLevel)
+	default:
+		log.Logger = log.Logger.Level(zerolog.InfoLevel)
+	}
 
 	log.Info().
 		Str("configPath", *configPath).

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -1,6 +1,7 @@
 package scrape
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"sync"
@@ -88,7 +89,12 @@ func Run(outwr io.Writer, config *userconfig.Meta) error {
 				return
 			}
 			defer r.Body.Close()
-			s := linksrc.NewSet(r.Body, lc, r.StatusCode)
+			ctx, cancel := context.WithTimeout(
+				context.Background(),
+				time.Duration(1)*time.Minute,
+			)
+			defer cancel()
+			s := linksrc.NewSet(ctx, r.Body, lc, r.StatusCode)
 
 			bc <- s
 

--- a/userconfig/userconfig_test.go
+++ b/userconfig/userconfig_test.go
@@ -116,6 +116,24 @@ scraping:
     interval: 5s
     storageDir: ./tempTestDir3012705204`,
 		},
+		{
+			description:   "valid link source with no link selector",
+			shouldBeError: false,
+			shouldBeEmpty: false,
+			conf: `---
+email:
+    smtpServerAddress: smtp://0.0.0.0:123
+    fromAddress: mynewsletter@example.com
+    toAddress: recipient@example.com
+    username: MyUser123
+    password: 123456-A_BCDE
+link_sources:
+    - name: site-38911
+      url: http://127.0.0.1:38911
+scraping:
+    interval: 5s
+    storageDir: ./tempTestDir3012705204`,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This simplifies configuration by allowing users to specify only the URL of a link source, with no need to dig into a website's CSS.

Set the link selector to `a` if it's empty in the configuraton. After finding all links on a site, group links automatically based on the HTML tags of their ancestors. E.g.,:

```html
<body>
  <div>
    <a>
    </a>
  </div>
</body>
```

Becomes `bodydiva`. Take the MD5 hash of each such string to prevent unbounded disk usage.

Also add timeouts to the scrapers since the fully automatic approach adds more work.

Add a log level flag to enable debug logging. This helps with investigations into automatic link parsing.