### PR TITLE
Improve email formatting

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -725,12 +725,13 @@ func TestOneOffFlagWithNoEmailFlag(t *testing.T) {
 		t.Fatalf("expected to receive zero emails but got %v", ems)
 	}
 
-	o, err := io.ReadAll(&msg)
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(&msg)
 	if err != nil {
 		t.Fatalf("could not read from the command output: %v", err)
 	}
 
-	links := smtptest.ExtractItems(string(o))
+	links := smtptest.ExtractItems(buf.String())
 	if len(links) != epubs*linksPerPub {
 		t.Errorf(
 			"expecting %v links via stdout, but got %v",

--- a/html/emailbody.go
+++ b/html/emailbody.go
@@ -32,9 +32,8 @@ func NewBodySectionContent(s linksrc.Set) BodySectionContent {
 		return bsc
 	}
 
-	bsc.Overview = "Here are the latest links:"
+	bsc.Overview = ""
 	return bsc
-
 }
 
 // Template meant to be populated with a []linksrc.Set
@@ -45,18 +44,16 @@ const emailBodyHTML = `<html>
 <head>
 </head>
 <body>
-	<table>
-		<tbody>
-			<h1>Here are some new links!</h1>
-			{{ range . }}
-				<h2>{{ .PubName }}</h2>
-				<p>{{ .Overview }}</p>
-				{{ range .Items }}
-					<p>{{ .Caption }} (<a href="{{ .LinkURL }}">here</a>)</p>
-				{{ end }}
-			{{ end }}
-		</tbody>
-	</table>
+	<p>One Newsletter found the following links.</p>
+	{{ range . }}
+		<h2>{{ .PubName }}</h2>
+		<p>{{ .Overview }}</p>
+		<ul>
+		{{ range .Items }}
+			<li>{{ .Caption }} (<a href="{{ .LinkURL }}">here</a>)</li>
+		{{ end }}
+		</ul>
+	{{ end }}
 </body>
 </html>`
 

--- a/html/emailbody_test.go
+++ b/html/emailbody_test.go
@@ -20,7 +20,6 @@ const (
 // delete the file at $relativeGoldenHTMLFilePath before running this test. Edits
 // to the golden file should be checked into version control.
 func TestGenerateBody(t *testing.T) {
-
 	ed := EmailData{
 		mtx: &sync.Mutex{},
 		content: []BodySectionContent{

--- a/html/golden-email-body.html
+++ b/html/golden-email-body.html
@@ -2,29 +2,29 @@
 <head>
 </head>
 <body>
-	<table>
-		<tbody>
-			<h1>Here are some new links!</h1>
-			
-				<h2>Example Site 1</h2>
-				<p>Here are the latest links:</p>
-				
-					<p>This is a hot take! (<a href="www.example.com/stories/hot-take">here</a>)</p>
-				
-					<p>Stuff happened today, yikes. (<a href="www.example.com/stories/stuff-happened">here</a>)</p>
-				
-					<p>Is this supposition really true? (<a href="www.example.com/storiesreally-true">here</a>)</p>
-				
-			
-				<h2>Example Site 2</h2>
-				<p>Here are the latest links:</p>
-				
-					<p>This was a tragedy (<a href="www.example.com/stories/tragedy">here</a>)</p>
-				
-					<p>This story is heartfelt (<a href="www.example.com/stories/heartfelt">here</a>)</p>
-				
-			
-		</tbody>
-	</table>
+	<p>One Newsletter found the following links.</p>
+	
+		<h2>Example Site 1</h2>
+		<p>Here are the latest links:</p>
+		<ul>
+		
+			<li>This is a hot take! (<a href="www.example.com/stories/hot-take">here</a>)</li>
+		
+			<li>Stuff happened today, yikes. (<a href="www.example.com/stories/stuff-happened">here</a>)</li>
+		
+			<li>Is this supposition really true? (<a href="www.example.com/storiesreally-true">here</a>)</li>
+		
+		</ul>
+	
+		<h2>Example Site 2</h2>
+		<p>Here are the latest links:</p>
+		<ul>
+		
+			<li>This was a tragedy (<a href="www.example.com/stories/tragedy">here</a>)</li>
+		
+			<li>This story is heartfelt (<a href="www.example.com/stories/heartfelt">here</a>)</li>
+		
+		</ul>
+	
 </body>
 </html>

--- a/smtptest/parseemail.go
+++ b/smtptest/parseemail.go
@@ -9,6 +9,6 @@ func ExtractItems(body string) []string {
 	if body == "" {
 		return []string{}
 	}
-	linkPattern := regexp.MustCompile("<p>.*\\(<a href=\".*\">.*</a>\\)</p>")
+	linkPattern := regexp.MustCompile("<li>.*\\(<a href=\".*\">.*</a>\\)</li>")
 	return linkPattern.FindAllString(body, -1)
 }


### PR DESCRIPTION
- Remove tables (these aren't needed)
- Use unordered lists instead of paragraphs for a more compact look that's easier to read.
- Remove "Here are the latest links" from emails