### PR TITLE
Make it easier to test local configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,17 +173,18 @@ check the results against past results, and send an email containing the new
 links. You can alter this behavior with the following flags:
 
 - `-oneoff`: Carry out a single scrape and send a single email. Since One
- Newsletter only saves the results of a scrape in order to carry out repeated
- checks, this flag also stops it from saving results to the database. Useful if
- you want to try out One Newsletter without waiting.
+  Newsletter only saves the results of a scrape in order to carry out repeated
+  checks, this flag also stops it from saving results to the database. Useful if
+  you want to try out One Newsletter in a "live" environment without waiting.
 
-- `-noemail`: Print an email's HTML to standard output rather than sending it.
- You can then redirect the HTML to a file of your choice or just read it from
- the terminal. Useful if you would like to run this on your local machine.
+- `-test`: Print an email's HTML to standard output rather than sending it.
+  Exits after the first email. You can then redirect the HTML to a file of your
+  choice or just read it from the terminal. Useful for testing your
+  configuration. Does not require any database or SMTP server configuration.
 
-You can use the `-oneoff` and `-noemail` flags together for a quick
-configuration check. One Newsletter will print the results of a scrape to your
-terminal without sending an email.
+- `-level`: The level of logs to show. Can be `error`, `info`, `debug`, or
+  `warn`. `info` by default. If you are using the `-test` flag, logging is
+  disabled unless you specify a level.
 
 ### How automatic link item detection works
 

--- a/e2e/appconfig.go
+++ b/e2e/appconfig.go
@@ -28,7 +28,7 @@ type appConfigOptions struct {
 	// Required
 	PollInterval string
 	OneOff       bool
-	NoEmail      bool
+	TestMode     bool
 }
 
 // mockLinksrcInfo contains metadata about test HTTP servers so we can use it
@@ -83,7 +83,7 @@ func createUserConfig(opts appConfigOptions) (userconfig.Meta, error) {
 			Interval:       v,
 			StorageDirPath: opts.StorageDir,
 			OneOff:         opts.OneOff,
-			NoEmail:        opts.NoEmail,
+			TestMode:       opts.TestMode,
 		},
 	}
 

--- a/storage/kv.go
+++ b/storage/kv.go
@@ -14,10 +14,10 @@ type KeyValue interface {
 	// Cleanup performs routine deletion of old records. We assign
 	// TTLs to KV pairs and delete them periodically.
 	Cleanup() error
-	// Drain/tear down the connection, or something analogous for an embedded
-	// database. Intended to be used with defer. Implementations should handle
-	// retries or drain connections internally and panic on failure, since there
-	// is nothing the program can do if it can't close the database.
+	// Drain/tear down the connection, or something analogous for an
+	// embedded database. Implementations should handle retries or drain
+	// connections internally and panic on failure, since there is nothing
+	// the program can do if it can't close the database.
 	Close()
 }
 

--- a/userconfig/userconfig.go
+++ b/userconfig/userconfig.go
@@ -34,8 +34,9 @@ type Scraping struct {
 	StorageDirPath string
 	// Run the scraper once, then exit
 	OneOff bool
-	// Print email text to stdout to help test configuration
-	NoEmail bool
+	// Print the HTML body of a single email to stdout and exit to help test
+	// configuration.
+	TestMode bool
 }
 
 // CheckAndSetDefaults validates s and either returns a copy of s with default
@@ -155,7 +156,7 @@ func Parse(r io.Reader) (*Meta, error) {
 
 	// Since this is a one-off or a test, set the data directory to an
 	// empty string to disable database operations.
-	if m.Scraping.OneOff || m.Scraping.NoEmail {
+	if m.Scraping.OneOff || m.Scraping.TestMode {
 		m.Scraping.StorageDirPath = ""
 		log.Debug().Msg(
 			"disabling database operations",

--- a/userconfig/userconfig_test.go
+++ b/userconfig/userconfig_test.go
@@ -231,7 +231,7 @@ func TestScrapingCheckAndSetDefaults(t *testing.T) {
 			input: Scraping{
 				Interval: mustParseDuration("5s"),
 				OneOff:   false,
-				NoEmail:  false,
+				TestMode: false,
 			},
 			expected:           Scraping{},
 			expectErrSubstring: "path",
@@ -240,7 +240,7 @@ func TestScrapingCheckAndSetDefaults(t *testing.T) {
 			description: "no interval",
 			input: Scraping{
 				OneOff:         false,
-				NoEmail:        false,
+				TestMode:       false,
 				StorageDirPath: "/storage",
 			},
 			expected:           Scraping{},
@@ -250,7 +250,7 @@ func TestScrapingCheckAndSetDefaults(t *testing.T) {
 			description: "interval less than 5s",
 			input: Scraping{
 				OneOff:         false,
-				NoEmail:        false,
+				TestMode:       false,
 				StorageDirPath: "/storage",
 				Interval:       mustParseDuration("100ms"),
 			},


### PR DESCRIPTION
Rename the `noemail` flag to `test`. Indicate that the `test` flag only sends a single email.

Modify the scraping flow:
  - Run the scrapers right away rather than waiting for the first tick. This makes it easier to check for config issues.
  - Don't continue scraping after the first scrape if in test mode.

e2e tests were failing after this, so this change also gets e2e tests to be more reliable:

  - Run the scrape loop in the main goroutine. Along with this, add an IterationLimit field to the scrape config. This makes e2e tests more deterministic and less flaky, since we can stop the scraper after a predetermined number of iterations, and don't need to rely on time passing.

   Also, when we ran StartLoop in a goroutine, the test suite would
   clean up the temporary directory used by the database before the
   database could close and release its directory lock, causing the
   database closure to fail.

 - This also removes the TestDBCleanup function, which is an e2e test that fails routinely. It's not really clear what this is testing and if this is testing what we want it to test!

Also disables logging in test mode by default to make config tests easier to read.