### PR TITLE
Fix link extraction with mixed hostnames

### DIFF
--- a/linksrc/autodetect.go
+++ b/linksrc/autodetect.go
@@ -423,26 +423,25 @@ func autoDetectLinkItems(n *html.Node, conf Config, links chan LinkItem, message
 			messages <- err.Error()
 		}
 		for _, c := range h {
-
 			t, err := extractCaptionFromContainer(c.container, conf.ShortElementFilter)
 			if err != nil {
 				messages <- err.Error()
 				continue
 			}
 			for _, a := range c.link.Attr {
-				if a.Key == "href" {
-					u, err := url.Parse(a.Val)
+				if a.Key != "href" {
+					continue
+				}
+				u, err := url.Parse(a.Val)
 
-					if err != nil {
-						messages <- fmt.Sprintf("Cannot parse the link URL %v", u)
-						continue
-					}
+				if err != nil {
+					messages <- fmt.Sprintf("Cannot parse the link URL %v", u)
+					continue
+				}
 
-					h := conf.URL.Scheme + "://" + conf.URL.Host + u.Path
-					links <- LinkItem{
-						LinkURL: h,
-						Caption: t,
-					}
+				links <- LinkItem{
+					LinkURL: getDisplayURL(conf.URL, *u),
+					Caption: t,
 				}
 			}
 		}

--- a/linksrc/linkitem_test.go
+++ b/linksrc/linkitem_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func TestLinkItem_Key(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		LinkItem LinkItem

--- a/linksrc/manualdetect.go
+++ b/linksrc/manualdetect.go
@@ -72,8 +72,6 @@ func manuallyDetectLinkItems(n *html.Node, conf Config, links chan LinkItem, mes
 			return
 		}
 
-		h = conf.URL.Scheme + "://" + conf.URL.Host + u.Path
-
 		if conf.CaptionSelector == nil {
 			messages <- "Could not parse the caption selector."
 			close(links)
@@ -102,7 +100,7 @@ func manuallyDetectLinkItems(n *html.Node, conf Config, links chan LinkItem, mes
 		}
 
 		links <- LinkItem{
-			LinkURL: h,
+			LinkURL: getDisplayURL(conf.URL, *u),
 			Caption: caption,
 		}
 	}

--- a/linksrc/set.go
+++ b/linksrc/set.go
@@ -5,12 +5,27 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
 	"golang.org/x/net/html"
 )
+
+// getDisplayURL determines how to display a URL found in a link within the
+// newsletter email. It uses the hostname found in the link within the link
+// source. If that's not available because the link is relative, it uses the
+// configured URL for the link source.
+func getDisplayURL(configURL, linkURL url.URL) string {
+	var host string
+	if linkURL.Host == "" {
+		host = configURL.Host
+	} else {
+		host = linkURL.Host
+	}
+	return configURL.Scheme + "://" + host + linkURL.Path
+}
 
 // NewSet initializes a new collection of listed link items for an HTML
 // document Reader, link source configuration, and HTTP status code (which

--- a/linksrc/set_test.go
+++ b/linksrc/set_test.go
@@ -84,6 +84,61 @@ func TestNewSet(t *testing.T) {
 			},
 		},
 		{
+			name: "links with different hostnames: manual",
+			html: mustReadFile(path.Join("testdata", "mixed-hostnames.html"), t),
+			conf: Config{
+				Name:               "My Cool Publication",
+				URL:                mustParseURL("http://www.example.com"),
+				ItemSelector:       css.MustCompile("body div#mostRead ol li"),
+				CaptionSelector:    css.MustCompile("div a.itemName"),
+				LinkSelector:       css.MustCompile("div a.itemName"),
+				ShortElementFilter: 3,
+			},
+			want: Set{
+				Name: "My Cool Publication",
+				items: map[string]LinkItem{
+					"http://subdomain1.example.com/stories/hot-take": {
+						LinkURL: "http://subdomain1.example.com/stories/hot-take",
+						Caption: "This is a hot take!",
+					},
+					"http://subdomain2.example.com/stories/stuff-happened": {
+						LinkURL: "http://subdomain2.example.com/stories/stuff-happened",
+						Caption: "Stuff happened today, yikes.",
+					},
+					"http://www.example.com/storiesreally-true": {
+						LinkURL: "http://www.example.com/storiesreally-true",
+						Caption: "Is this supposition really true?",
+					},
+				},
+			},
+		},
+		{
+			name: "links with different hostnames: automatic",
+			html: mustReadFile(path.Join("testdata", "mixed-hostnames.html"), t),
+			conf: Config{
+				Name:               "My Cool Publication",
+				URL:                mustParseURL("http://www.example.com"),
+				ShortElementFilter: 3,
+			},
+			want: Set{
+				Name: "My Cool Publication",
+				items: map[string]LinkItem{
+					"http://subdomain1.example.com/stories/hot-take": {
+						LinkURL: "http://subdomain1.example.com/stories/hot-take",
+						Caption: "This is a hot take!",
+					},
+					"http://subdomain2.example.com/stories/stuff-happened": {
+						LinkURL: "http://subdomain2.example.com/stories/stuff-happened",
+						Caption: "Stuff happened today, yikes.",
+					},
+					"http://www.example.com/storiesreally-true": {
+						LinkURL: "http://www.example.com/storiesreally-true",
+						Caption: "Is this supposition really true?",
+					},
+				},
+			},
+		},
+		{
 			name: "canonical/intended case with relative link URLs",
 			html: mustReadFile(path.Join("testdata", "straightforward-relative-links.html"), t),
 			conf: Config{

--- a/linksrc/testdata/aldaily.html
+++ b/linksrc/testdata/aldaily.html
@@ -52,7 +52,7 @@
           mutilated. So it was with
           <strong><span>Czeslaw Milosz</span>&nbsp;in California</strong
           >...&nbsp;<a
-            href="https://example.com/latest/miloszs-magic-mountain-neumeyer"
+            href="https://www.example.com/latest/miloszs-magic-mountain-neumeyer"
             >more&nbsp;»</a
           >
         </p>

--- a/linksrc/testdata/intelligencer-feed.html
+++ b/linksrc/testdata/intelligencer-feed.html
@@ -25,7 +25,7 @@
         <div class="feed-header">THE FEED</div>
         <div class="feed-container">
           <a
-            href="http://example.com/intelligencer/2022/04/subway-shooting-proved-regular-new-yorkers-fight-crime-too.html"
+            href="http://www.example.com/intelligencer/2022/04/subway-shooting-proved-regular-new-yorkers-fight-crime-too.html"
             class="feed-item article"
           >
             <div class="feed-item-timestamp-container">
@@ -96,7 +96,7 @@
             </div>
           </a>
           <a
-            href="http://example.com/intelligencer/2022/04/what-happened-to-paxlovid-the-covid-19-wonder-drug.html"
+            href="http://www.example.com/intelligencer/2022/04/what-happened-to-paxlovid-the-covid-19-wonder-drug.html"
             class="feed-item article"
           >
             <div class="feed-item-timestamp-container">
@@ -168,7 +168,7 @@
           </a>
           <div class="feed-ad"></div>
           <a
-            href="http://example.com/intelligencer/article/what-republicans-mean-rigged-election.html"
+            href="http://www.example.com/intelligencer/article/what-republicans-mean-rigged-election.html"
             class="feed-item article"
           >
             <div class="feed-item-timestamp-container">

--- a/linksrc/testdata/mixed-hostnames.html
+++ b/linksrc/testdata/mixed-hostnames.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>This is my website</title>
+  </head>
+  <body>
+    <h1>This is my cool website</h1>
+    <div id="mostRead">
+      <h2>Most read posts today</h2>
+      <ol>
+        <li>
+          <img src="img1.png" alt="A cool image" />
+          <div class="byline">By <strong>the staff</strong></div>
+          <div class="itemHolder">
+            <a href="http://subdomain1.example.com/stories/hot-take" class="itemName"
+              >This is a hot take!</a
+            >
+          </div>
+        </li>
+        <li>
+          <img src="img2.png" alt="This is an image" />
+          <div class="byline">By <strong>the staff</strong></div>
+          <div class="itemHolder">
+            <a
+              href="http://subdomain2.example.com/stories/stuff-happened"
+              class="itemName"
+              >Stuff happened today, yikes.</a
+            >
+          </div>
+        </li>
+        <li>
+          <img src="img3.png" alt="This is also an image" />
+          <div class="byline">By <strong>the staff</strong></div>
+          <div class="itemHolder">
+            <a href="http://www.example.com/storiesreally-true" class="itemName"
+              >Is this supposition really true?</a
+            >
+          </div>
+        </li>
+      </ol>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
In link sources that include links to the same site as well as external sites, the scraper would treat all links as though they targeted the same site.

This is because it uses the hostname of a configured link source to build the URLs to include in the emails it sends. If a link URL has a hostname that differs from the link source's hostname, the scraper uses the link source's hostname anyway.

This change fixes this behavior and uses the hostname found within a link URL if it is available.