### PR TITLE
Add support for notification schedules

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,15 +42,11 @@
 
 1. Make it easier to test configurations locally.
 
-   - Add a `-test` flag that combines `-oneoff` and `-noemail`.
    - For `-test`, don't include verbose logs.
    - For `-oneoff` and `-noemail` operations, don't touch the data directory
    - For `-test`, only read the `link_sources` part of the config.
 
 1. Don't include verbose logs for `oneoff` operations.
-
-1. Deprecate manual newsletter configuration (i.e., where you need to specify
-   the link container, caption selector, and link selector).
 
 1. Find an alternative to static passwords stored in the config file.
 
@@ -68,10 +64,6 @@
 1. Update the third-party licenses table using a CI job (probably using GitHub
    Actions) and [`go-licenses`](https://github.com/google/go-licenses). Or use a
    make target.
-
-1. Make `TestDBCleanup` (`e2e/e2e_test.go`) more deterministic and faster
-   running. Right now, it takes the longest of all e2e tests and sometimes
-   fails.
 
 ## Making the newsletter more useful
 

--- a/e2e/appconfig.go
+++ b/e2e/appconfig.go
@@ -3,8 +3,6 @@ package e2e
 import (
 	"errors"
 	"net/url"
-	"strings"
-	"time"
 
 	"github.com/andybalholm/cascadia"
 	"github.com/ptgott/one-newsletter/email"
@@ -12,68 +10,18 @@ import (
 	"github.com/ptgott/one-newsletter/userconfig"
 )
 
-// appConfigOptions is used to fill in a config template with details unique to
-// a specific test environment. Keep this as small as possible so the input
-// remains as close to a "real" YAML document as we can make it. Also using
-// YAML/JSON-compatible types only here.
-//
-// Fields are exported so we can use them in templates.
-// TODO: No reason to keep this around anymore. Use the regular config instead.
-type appConfigOptions struct {
-	// Required. Includes host and port.
-	SMTPServerAddress string
-	// Required
-	LinkSources []mockLinksrcInfo
-	// Required
-	StorageDir string
-	// Required
-	PollInterval string
-	OneOff       bool
-	TestMode     bool
-}
-
-// mockLinksrcInfo contains metadata about test HTTP servers so we can use it
-// to configure scraping targets for the application within a test environment.
-type mockLinksrcInfo struct {
-	// Required
-	URL string
-	// Required
-	Name string
-	// Not required
-	MaxItems int
-	// Not required
-	LinkSelector string
-	// Not required
-	CaptionSelector string
-	// Not required
-	ItemSelector string
-	// The linkSelector, captionSelector, and itemSelector in a link source
-	// config. Leave blank if you would like to use valid defaults.
-	SelectorsOverride string
-}
-
 // createUserConfig creates a user configuration based on the provided
-// appConfigOptions. Non-required options are populated automatically using
+// starter config. Non-required options are populated automatically using
 // defaults intended for e2e testing.
-func createUserConfig(opts appConfigOptions) (userconfig.Meta, error) {
-	if opts.LinkSources == nil || opts.SMTPServerAddress == "" || opts.PollInterval == "" || opts.StorageDir == "" {
+func createUserConfig(opts userconfig.Meta) (userconfig.Meta, error) {
+	if opts.LinkSources == nil || opts.EmailSettings.SMTPServerHost == "" || opts.EmailSettings.SMTPServerPort == "" || opts.Scraping.StorageDirPath == "" {
 		return userconfig.Meta{}, errors.New("must supply all required fields in appConfigOptions")
-	}
-	v, err := time.ParseDuration(opts.PollInterval)
-	if err != nil {
-		return userconfig.Meta{}, err
-	}
-
-	hp := strings.Split(opts.SMTPServerAddress, ":")
-
-	if len(hp) != 2 {
-		return userconfig.Meta{}, errors.New("SMTPServerAddress must be in the form host:port")
 	}
 
 	config := userconfig.Meta{
 		EmailSettings: email.UserConfig{
-			SMTPServerHost:       hp[0],
-			SMTPServerPort:       hp[1],
+			SMTPServerHost:       opts.EmailSettings.SMTPServerHost,
+			SMTPServerPort:       opts.EmailSettings.SMTPServerPort,
 			FromAddress:          "mynewsletter@example.com",
 			ToAddress:            "recipient@example.com",
 			UserName:             "myuser",
@@ -81,38 +29,34 @@ func createUserConfig(opts appConfigOptions) (userconfig.Meta, error) {
 			SkipCertVerification: true,
 		},
 		Scraping: userconfig.Scraping{
-			Interval:       v,
-			StorageDirPath: opts.StorageDir,
-			OneOff:         opts.OneOff,
-			TestMode:       opts.TestMode,
+			StorageDirPath: opts.Scraping.StorageDirPath,
+			OneOff:         opts.Scraping.OneOff,
+			TestMode:       opts.Scraping.TestMode,
 			LinkExpiryDays: 180,
 		},
 	}
 
 	config.LinkSources = make([]linksrc.Config, len(opts.LinkSources))
+	blankURL := url.URL{}
 	for i, ls := range opts.LinkSources {
-		if ls.URL == "" || ls.Name == "" {
-			return userconfig.Meta{}, errors.New("each mockLinksrcInfo must include a URL and Name")
-		}
-		u, err := url.Parse(ls.URL)
-		if err != nil {
-			return userconfig.Meta{}, err
+		if ls.URL == blankURL || ls.Name == "" {
+			return userconfig.Meta{}, errors.New("each link source must include a URL and Name")
 		}
 		config.LinkSources[i] = linksrc.Config{
 			Name:            ls.Name,
-			URL:             *u,
+			URL:             ls.URL,
 			MaxItems:        uint(ls.MaxItems),
 			ItemSelector:    cascadia.MustCompile("ul li"),
 			CaptionSelector: cascadia.MustCompile("p"),
 			LinkSelector:    cascadia.MustCompile("a"),
 		}
 		switch {
-		case ls.CaptionSelector != "":
-			config.LinkSources[i].CaptionSelector = cascadia.MustCompile(ls.CaptionSelector)
-		case ls.ItemSelector != "":
-			config.LinkSources[i].ItemSelector = cascadia.MustCompile(ls.ItemSelector)
-		case ls.LinkSelector != "":
-			config.LinkSources[i].LinkSelector = cascadia.MustCompile(ls.LinkSelector)
+		case ls.CaptionSelector != nil:
+			config.LinkSources[i].CaptionSelector = ls.CaptionSelector
+		case ls.ItemSelector != nil:
+			config.LinkSources[i].ItemSelector = ls.ItemSelector
+		case ls.LinkSelector != nil:
+			config.LinkSources[i].LinkSelector = ls.LinkSelector
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -105,12 +105,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	sched := userconfig.NewScheduleStore()
+	sched.Add(userconfig.DefaultScheduleName, checkedConfig.Scraping.Schedule)
+
 	log.Info().Str("configPath", *configPath).Msg("successfully validated the config")
 
-	scrapeCadence := time.NewTicker(config.Scraping.Interval)
 	scrapeConfig := scrape.Config{
-		TickCh:   scrapeCadence.C,
-		OutputWr: os.Stdout, // write to stdout if the -no-email flag is given
+		TickCh:        time.NewTicker(time.Minute).C,
+		OutputWr:      os.Stdout, // write to stdout if the -no-email flag is given
+		ScheduleStore: sched,
 	}
 
 	if err := scrape.StartLoop(&scrapeConfig, &checkedConfig); err != nil {

--- a/smtptest/test-smpt-server.go
+++ b/smtptest/test-smpt-server.go
@@ -20,7 +20,6 @@ type Server interface {
 	// server during the test/suite after time t in Unix epoch seconds.
 	RetrieveEmails(t int64) ([]string, error)
 
-	// Address returns the address of the server. Getting this could vary
-	// between implementations, so we make it a method.
+	// Address returns the address of the server.
 	Address() string
 }

--- a/userconfig/userconfig.go
+++ b/userconfig/userconfig.go
@@ -4,7 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"regexp"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/ptgott/one-newsletter/linksrc"
@@ -15,11 +18,6 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// Scrapes must take place at a minimum every 5s. We'll probably use a much
-// larger interval for a daily newsletter, but 5s is a failsafe to make
-// sure we're not accidentally DOSing our link sources.
-const minDurationMS int64 = 5000 // using MS since it's an int not a float
-
 // Meta represents all current config options that the application can use,
 // i.e., after validation and parsing
 type Meta struct {
@@ -28,10 +26,124 @@ type Meta struct {
 	LinkSources   []linksrc.Config `yaml:"link_sources"`
 }
 
+// Weekdays is a bitmap indicating the days of the week in which to send a
+// newsletter.
+type Weekdays int
+
+const (
+	Monday Weekdays = 1 << iota
+	Tuesday
+	Wednesday
+	Thursday
+	Friday
+	Saturday
+	Sunday
+)
+
+var allDays [7]Weekdays = [7]Weekdays{
+	Monday,
+	Tuesday,
+	Wednesday,
+	Thursday,
+	Friday,
+	Saturday,
+	Sunday,
+}
+
+var daysToTime map[Weekdays]time.Weekday = map[Weekdays]time.Weekday{
+	Monday:    time.Monday,
+	Tuesday:   time.Tuesday,
+	Wednesday: time.Wednesday,
+	Thursday:  time.Thursday,
+	Friday:    time.Friday,
+	Saturday:  time.Saturday,
+	Sunday:    time.Sunday,
+}
+
+const DefaultScheduleName = "newsletter"
+
+type NotificationSchedule struct {
+	Weekdays Weekdays
+	Hour     int
+}
+
+// Moment specifies attributes of a time as returned by methods of
+// time.Time. It is used to determine whether the current time belongs to a
+// notification schedule.
+type Moment struct {
+	Day  time.Weekday
+	Hour int
+}
+
+// moments gets the notificationMoments that correspond to a
+// NotificationSchedule. Consumers can map notificationMoments to, for example,
+// the originating NotificationSchedules or configurations as well as determine
+// whether a schedule belongs to the current time.
+func moments(s NotificationSchedule) []Moment {
+	res := []Moment{}
+	for _, d := range allDays {
+		if s.Weekdays&d != d {
+			continue
+		}
+		res = append(res, Moment{
+			Day:  daysToTime[d],
+			Hour: s.Hour,
+		})
+	}
+	return res
+}
+
+// ScheduleStore tracks handles for NotificationSchedules, mapping moments to
+// them so we can look up a given schedule by the current moment.
+type ScheduleStore struct {
+	moments    map[Moment][]string
+	mu         *sync.Mutex
+	lastMoment Moment
+	// lastDate is the last date we queried a moment in RFC 3339 format,
+	// e.g., 2025-06-05.
+	lastDate string
+}
+
+// NewScheduleStore initializes an empty ScheduleStore.
+func NewScheduleStore() *ScheduleStore {
+	return &ScheduleStore{
+		moments: make(map[Moment][]string),
+		mu:      &sync.Mutex{},
+	}
+}
+
+// Add includes sched in the ScheduleStore so we can look it up later by moment.
+func (s *ScheduleStore) Add(handle string, sched NotificationSchedule) {
+	for _, m := range moments(sched) {
+		if _, ok := s.moments[m]; !ok {
+			s.moments[m] = []string{}
+		}
+		s.moments[m] = append(s.moments[m], handle)
+	}
+}
+
+// Get returns a slice of NotificationSchedule handles that match the given
+// notification moment.
+func (s *ScheduleStore) Get(t time.Time) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	m := Moment{
+		Day:  t.Weekday(),
+		Hour: t.Hour(),
+	}
+	d := t.Format(time.DateOnly)
+	if s.lastMoment == m && s.lastDate == d {
+		return []string{}
+	}
+	s.lastMoment = m
+	s.lastDate = d
+	return s.moments[m]
+}
+
 // Scraping contains config options that apply to One Newsletter's scraping
 // behavior
 type Scraping struct {
-	Interval       time.Duration
+	Schedule       NotificationSchedule
 	StorageDirPath string
 	// Run the scraper once, then exit
 	OneOff bool
@@ -46,18 +158,6 @@ type Scraping struct {
 // CheckAndSetDefaults validates s and either returns a copy of s with default
 // settings applied or returns an error due to an invalid configuration
 func (s *Scraping) CheckAndSetDefaults() (Scraping, error) {
-
-	i := s.Interval.Milliseconds()
-	if i == 0 {
-		return Scraping{}, errors.New(
-			"user-provided config does not include a polling interval",
-		)
-	}
-
-	if i < minDurationMS {
-		minDurS := minDurationMS / 1000
-		return Scraping{}, fmt.Errorf("polling interval must be at least %v seconds", minDurS)
-	}
 	if s.StorageDirPath == "" {
 		return Scraping{}, errors.New(
 			"user-provided config does not include a storage path",
@@ -75,27 +175,9 @@ func (s *Scraping) CheckAndSetDefaults() (Scraping, error) {
 func (s *Scraping) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	v := make(map[string]string)
 	err := unmarshal(&v)
-
 	if err != nil {
 		return fmt.Errorf("can't parse the user config: %v", err)
 	}
-
-	d, ok := v["interval"]
-
-	if !ok {
-		d = "0s"
-	}
-
-	pd, err := time.ParseDuration(d)
-
-	if err != nil {
-		return fmt.Errorf(
-			"can't parse the user-provided polling interval as a duration: %v",
-			err,
-		)
-	}
-
-	s.Interval = pd
 
 	sp, ok := v["storageDir"]
 	if !ok {
@@ -111,9 +193,20 @@ func (s *Scraping) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	lid, err := strconv.Atoi(li)
 	if err != nil {
-		return fmt.Errorf("can't parse the link expiry as an integer")
+		return errors.New("can't parse the link expiry as an integer")
 	}
 	s.LinkExpiryDays = uint(lid)
+
+	ni, ok := v["schedule"]
+	if !ok {
+		return errors.New("the configuration must provide a notification schedule")
+	}
+
+	n, err := parseNotificationSchedule(ni)
+	if err != nil {
+		return fmt.Errorf("cannot parse the notification schedule: %w", err)
+	}
+	s.Schedule = n
 
 	return nil
 }
@@ -183,4 +276,44 @@ func Parse(r io.Reader) (*Meta, error) {
 
 	return &m, nil
 
+}
+
+var dayMarkerPattern = regexp.MustCompile(`[A-Z][a-z]?`)
+
+// parseNotificationSchedule creates a NotificationSchedule based on the value
+// in val. It returns an error if the value is invalid.
+func parseNotificationSchedule(val string) (NotificationSchedule, error) {
+	parts := strings.Split(val, " ")
+	if len(parts) != 2 {
+		return NotificationSchedule{}, errors.New(`notification schedules must include days and an hour, separated by a space, such as "MWF 12"`)
+	}
+
+	ret := NotificationSchedule{}
+	days := dayMarkerPattern.FindAllString(parts[0], -1)
+	for _, d := range days {
+		switch d {
+		case "M":
+			ret.Weekdays |= Monday
+		case "Tu":
+			ret.Weekdays |= Tuesday
+		case "W":
+			ret.Weekdays |= Wednesday
+		case "Th":
+			ret.Weekdays |= Thursday
+		case "F":
+			ret.Weekdays |= Friday
+		case "Sa":
+			ret.Weekdays |= Saturday
+		case "Su":
+			ret.Weekdays |= Sunday
+		default:
+			return NotificationSchedule{}, fmt.Errorf("not a valid notification schedule day: %q", d)
+		}
+	}
+	h, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return NotificationSchedule{}, fmt.Errorf("cannot convert %v into an hour while parsing a notification schedule: cannot be converted into an integer - did you swap the hour and days?", parts[1])
+	}
+	ret.Hour = h
+	return ret, nil
 }


### PR DESCRIPTION
Rather than send the newsletter at user-defined intervals, expose notification schedules in the configuration, letting the user configure the newsletter to be sent at specific days and times. The scraping configuration now takes a schedule store, which contains configured notification schedules.

Every tick of a ticker, we look up the current time within the schedule store. If there is a match, we send a newsletter. Notification schedules are currently limited to hours and days of the week: there cannot be multiple mailings of the same newsletter within the same hour.

Also remove the `IterationLimit` configuration field, since this was used in e2e tests to guarantee a certain number of email sends. But this logic doens't make sense if we're using notification schedules.