### PR TITLE
Add support for multiple newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,18 @@ Run the following command:
 onenewsletter -config path/to/config.yaml
 ```
 
-### Link sources and link items
+## Link sources and link items
 
 One Newsletter works by scraping **link sources**, web pages with lists of links
 to other web pages. These lists of links are called **link items**, and each one
 is assumed to have both a link URL and a caption that describes the URL.
 
-### Configuration
+## Configuration
 
 One Newsletter reads its configuration from the YAML file at the `-config` path.
-The file has the following structure.
+This section explains the top-level fields of the configuration file.
+
+### `email`
 
 `email` configures the SMTP relay. The relay must advertise STARTTLS and AUTH.
 One Newsletter negotiates a TLS connection and uses your username and pasword to
@@ -57,6 +59,8 @@ email:
   username: MyUser123
   password: 123456-A_BCDE
 ```
+
+### `scraping`
 
 `scraping` configures the scraper.
 
@@ -83,11 +87,62 @@ scraping:
   linkExpiryDays: 100
 ```
 
-The `link_sources` section tells One Newsletter how to scrape websites for
-links. One Newsletter tracks these as **link sources**. Each link source
-includes a menu of links (e.g., a "Most Read" list), and One Newsletter scrapes
-these menus for updates by examining the structure of its **link items**, i.e.,
-a link and its surrounding HTML.
+### `newsletters`
+
+You can configure One Newsletter to include content from specific sites on
+particular days of the week. To configure the sites to include in each
+email, and when those emails arrive in your inbox, use the `newsletters`
+section.
+
+`newsletters` is a map of strings to objects. The key of each item represents
+the name of the newsletter. Each object specifies the newsletter's link sources
+and notification schedule:
+
+```yaml
+newsletters:
+  newsletter1:
+    schedule: MWF 12
+    link_sources:
+      - name: mysite
+        url: https://example.com/rss
+  newsletter2:
+    schedule: Th 14
+    link_sources:
+      - name: mysite
+        url: https://example.com/rss
+
+```
+
+#### Notification schedules
+
+For each newsletter, you can configure the days of the week and time of day that
+One Newsletter sends an email. The syntax is:
+
+```
+<days of the week> <time of day>
+```
+
+The following days of the week are available:
+
+|String|Day|
+|---|---|
+|`M`|Monday|
+|`Tu`|Tuesday|
+|`W`|Wednesday|
+|`Th`|Thursday|
+|`F`|Friday|
+|`Sa`|Saturday|
+|`Su`|Sunday|
+
+The time of day is a single hour between 1 and 24.
+
+#### `link_sources`
+
+In each newsletter configuration, the `link_sources` section tells One
+Newsletter how to scrape websites for links. One Newsletter tracks these as
+**link sources**. Each link source includes a menu of links (e.g., a "Most Read"
+list), and One Newsletter scrapes these menus for updates by examining the
+structure of its **link items**, i.e., a link and its surrounding HTML.
 
 You can instruct One Newsletter to scrape links at three levels of specificity,
 depending on how much you can tolerate unexpected results and you want to dig
@@ -173,7 +228,7 @@ link_sources:
     minElementWords: 5
 ```
 
-### Optional flags
+## Optional flags
 
 By default, One Newsletter will periodically scrape the websites of your choice,
 check the results against past results, and send an email containing the new
@@ -193,7 +248,7 @@ links. You can alter this behavior with the following flags:
   `warn`. `info` by default. If you are using the `-test` flag, logging is
   disabled unless you specify a level.
 
-### How automatic link item detection works
+## How automatic link item detection works
 
 Automatic link item detection works from the assumption that each link sits in a
 chunk of automatically generated HTML, e.g., the result of server-side template

--- a/e2e/appconfig.go
+++ b/e2e/appconfig.go
@@ -14,7 +14,7 @@ import (
 // starter config. Non-required options are populated automatically using
 // defaults intended for e2e testing.
 func createUserConfig(opts userconfig.Meta) (userconfig.Meta, error) {
-	if opts.LinkSources == nil || opts.EmailSettings.SMTPServerHost == "" || opts.EmailSettings.SMTPServerPort == "" || opts.Scraping.StorageDirPath == "" {
+	if opts.Newsletters == nil || len(opts.Newsletters) == 0 || opts.EmailSettings.SMTPServerHost == "" || opts.EmailSettings.SMTPServerPort == "" || opts.Scraping.StorageDirPath == "" {
 		return userconfig.Meta{}, errors.New("must supply all required fields in appConfigOptions")
 	}
 
@@ -29,6 +29,7 @@ func createUserConfig(opts userconfig.Meta) (userconfig.Meta, error) {
 			SkipCertVerification: true,
 		},
 		Scraping: userconfig.Scraping{
+			NewsletterName: opts.Scraping.NewsletterName,
 			StorageDirPath: opts.Scraping.StorageDirPath,
 			OneOff:         opts.Scraping.OneOff,
 			TestMode:       opts.Scraping.TestMode,
@@ -36,30 +37,38 @@ func createUserConfig(opts userconfig.Meta) (userconfig.Meta, error) {
 		},
 	}
 
-	config.LinkSources = make([]linksrc.Config, len(opts.LinkSources))
-	blankURL := url.URL{}
-	for i, ls := range opts.LinkSources {
-		if ls.URL == blankURL || ls.Name == "" {
-			return userconfig.Meta{}, errors.New("each link source must include a URL and Name")
+	newsletters := make(map[string]userconfig.Newsletter)
+
+	for k, n := range opts.Newsletters {
+		sources := make([]linksrc.Config, len(n.LinkSources))
+		blankURL := url.URL{}
+		for i, ls := range n.LinkSources {
+			if ls.URL == blankURL || ls.Name == "" {
+				return userconfig.Meta{}, errors.New("each link source must include a URL and Name")
+			}
+			sources[i] = linksrc.Config{
+				Name:            ls.Name,
+				URL:             ls.URL,
+				MaxItems:        uint(ls.MaxItems),
+				ItemSelector:    cascadia.MustCompile("ul li"),
+				CaptionSelector: cascadia.MustCompile("p"),
+				LinkSelector:    cascadia.MustCompile("a"),
+			}
+			switch {
+			case ls.CaptionSelector != nil:
+				sources[i].CaptionSelector = ls.CaptionSelector
+			case ls.ItemSelector != nil:
+				sources[i].ItemSelector = ls.ItemSelector
+			case ls.LinkSelector != nil:
+				sources[i].LinkSelector = ls.LinkSelector
+			}
 		}
-		config.LinkSources[i] = linksrc.Config{
-			Name:            ls.Name,
-			URL:             ls.URL,
-			MaxItems:        uint(ls.MaxItems),
-			ItemSelector:    cascadia.MustCompile("ul li"),
-			CaptionSelector: cascadia.MustCompile("p"),
-			LinkSelector:    cascadia.MustCompile("a"),
-		}
-		switch {
-		case ls.CaptionSelector != nil:
-			config.LinkSources[i].CaptionSelector = ls.CaptionSelector
-		case ls.ItemSelector != nil:
-			config.LinkSources[i].ItemSelector = ls.ItemSelector
-		case ls.LinkSelector != nil:
-			config.LinkSources[i].LinkSelector = ls.LinkSelector
+		newsletters[k] = userconfig.Newsletter{
+			Schedule:    n.Schedule,
+			LinkSources: sources,
 		}
 	}
+	config.Newsletters = newsletters
 
 	return config, nil
-
 }

--- a/e2e/doc.go
+++ b/e2e/doc.go
@@ -1,5 +1,6 @@
 package e2e
 
-// e2e contains end-to-end tests and utility code required to set up
-// dependencies. Note that some e2e test dependencies are also used by
-// unit tests--these dependencies are not included here.
+// e2e contains integration tests and utility code required to set up
+// dependencies. Note that some e2e test dependencies are also used by unit
+// tests--these dependencies are not included here. (These were intended to be
+// end-to-end tests but became integration tests instead, hence the name.)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ptgott/one-newsletter/smtptest"
 	"github.com/ptgott/one-newsletter/userconfig"
 	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -46,10 +47,9 @@ func fakeTickChan(count int) (userconfig.NotificationSchedule, []time.Time) {
 	return sched, c
 }
 
-// Check that the number of emails sent is within the expected range.
-// Declare a test environment with a number of fake e-publications, run the
-// application as a child process, wait for an interval, then stop the
-// subprocess to count emails sent.
+// Check that the number of emails sent is within the expected range. Declare a
+// test environment with a number of fake e-publications, run the application,
+// wait for an interval, then stop the subprocess to count emails sent.
 func TestNewsletterEmailSending(t *testing.T) {
 	expectedEmails := 3
 	epubs := 3
@@ -87,9 +87,13 @@ func TestNewsletterEmailSending(t *testing.T) {
 				SMTPServerHost: hostport[0],
 				SMTPServerPort: hostport[1],
 			},
-			LinkSources: u,
+			Newsletters: map[string]userconfig.Newsletter{
+				"mynewsletter": userconfig.Newsletter{
+					LinkSources: u,
+					Schedule:    sched,
+				},
+			},
 			Scraping: userconfig.Scraping{
-				Schedule:       sched,
 				StorageDirPath: testenv.tempDirPath,
 			},
 		},
@@ -100,7 +104,7 @@ func TestNewsletterEmailSending(t *testing.T) {
 
 	ch := make(chan time.Time, 1)
 	store := userconfig.NewScheduleStore()
-	store.Add("myschedule", sched)
+	store.Add("mynewsletter", sched)
 	scrapeConfig := scrape.Config{
 		ScheduleStore: store,
 		TickCh:        ch,
@@ -173,12 +177,17 @@ func TestNewsletterEmailUpdates(t *testing.T) {
 				SMTPServerHost: hostport[0],
 				SMTPServerPort: hostport[1],
 			},
-			LinkSources: u,
-			Scraping: userconfig.Scraping{
-				Schedule: userconfig.NotificationSchedule{
-					Weekdays: userconfig.Monday,
-					Hour:     12,
+			Newsletters: map[string]userconfig.Newsletter{
+				"mynewsletter": userconfig.Newsletter{
+					LinkSources: u,
+					Schedule: userconfig.NotificationSchedule{
+						Weekdays: userconfig.Monday,
+						Hour:     12,
+					},
 				},
+			},
+			Scraping: userconfig.Scraping{
+
 				StorageDirPath: testenv.tempDirPath,
 			},
 		},
@@ -187,13 +196,24 @@ func TestNewsletterEmailUpdates(t *testing.T) {
 		panic(fmt.Sprintf("can't create the app config: %v", err))
 	}
 
-	// Closing the channel immediately since we're relying on the initial
-	// email sent in StartLoop.
+	// We want to test the second email, since the first is a summary. Start
+	// a fake tick channel for one email. The first should send right away
+	// before the ticks start.
+	sched, ticks := fakeTickChan(1)
 	ch := make(chan time.Time, 1)
-	close(ch)
+	store := userconfig.NewScheduleStore()
+	store.Add("mynewsletter", sched)
 	scrapeConfig := scrape.Config{
-		TickCh: ch,
+		ScheduleStore: store,
+		TickCh:        ch,
 	}
+
+	go func() {
+		for i := range ticks {
+			ch <- ticks[i]
+		}
+		close(ch)
+	}()
 
 	scrape.StartLoop(&scrapeConfig, &config)
 	// Wait for the application to poll the link site, check for emails,
@@ -203,26 +223,43 @@ func TestNewsletterEmailUpdates(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not retrieve emails before the update: %v", err)
 	}
-	if len(em1) == 0 {
-		t.Fatal("retrieved zero emails before the update")
-	}
-	before := em1[0] // should just be one email at this point
+
+	// There should be an initial summary email and a newsletter.
+	require.Equal(t, 2, len(em1))
+
+	// Check the link newsletter
+	before := em1[1]
 	log.Info().Msg("updating the mock link sites")
 	testenv.update(linksToUpdate)
 	ut := time.Now().UnixNano()
 	log.Info().Msg("finished updating the mock link sites")
+
+	// Start another tick channel to test the update.
+	sched, ticks = fakeTickChan(1)
+	ch = make(chan time.Time, 1)
+	store = userconfig.NewScheduleStore()
+	store.Add("mynewsletter", sched)
+	scrapeConfig = scrape.Config{
+		ScheduleStore: store,
+		TickCh:        ch,
+	}
+
+	go func() {
+		for i := range ticks {
+			ch <- ticks[i]
+		}
+		close(ch)
+	}()
 
 	scrape.StartLoop(&scrapeConfig, &config)
 	em2, err := testenv.SMTPServer.RetrieveEmails(ut)
 	if err != nil {
 		t.Errorf("can't retrieve emails after the update: %v", err)
 	}
-	if len(em2) == 0 {
-		t.Fatal("retrieved zero emails after the update")
-	}
+	// As before, there should be an initial summary email and a newsletter.
+	require.Equal(t, 2, len(em2))
 
-	// There should just be one email after filtering by time
-	after := em2[0]
+	after := em2[1]
 
 	linksBefore := smtptest.ExtractItems(before)
 	linksAfter := smtptest.ExtractItems(after)
@@ -290,12 +327,17 @@ func TestMaxLinkLimits(t *testing.T) {
 				SMTPServerHost: hostport[0],
 				SMTPServerPort: hostport[1],
 			},
-			LinkSources: u,
-			Scraping: userconfig.Scraping{
-				Schedule: userconfig.NotificationSchedule{
-					Weekdays: userconfig.Monday,
-					Hour:     12,
+			Newsletters: map[string]userconfig.Newsletter{
+				"mynewsletter": userconfig.Newsletter{
+					LinkSources: u,
+					Schedule: userconfig.NotificationSchedule{
+						Weekdays: userconfig.Monday,
+						Hour:     12,
+					},
 				},
+			},
+			Scraping: userconfig.Scraping{
+
 				StorageDirPath: testenv.tempDirPath,
 			},
 		},
@@ -407,12 +449,16 @@ func TestEmailSendingWithBadScrapeConfig(t *testing.T) {
 				SMTPServerHost: hostport[0],
 				SMTPServerPort: hostport[1],
 			},
-			LinkSources: u,
-			Scraping: userconfig.Scraping{
-				Schedule: userconfig.NotificationSchedule{
-					Weekdays: userconfig.Monday,
-					Hour:     12,
+			Newsletters: map[string]userconfig.Newsletter{
+				"mynewsletter": userconfig.Newsletter{
+					LinkSources: u,
+					Schedule: userconfig.NotificationSchedule{
+						Weekdays: userconfig.Monday,
+						Hour:     12,
+					},
 				},
+			},
+			Scraping: userconfig.Scraping{
 				StorageDirPath: testenv.tempDirPath,
 			},
 		},
@@ -423,7 +469,7 @@ func TestEmailSendingWithBadScrapeConfig(t *testing.T) {
 
 	ch := make(chan time.Time, 1)
 	store := userconfig.NewScheduleStore()
-	store.Add("myschedule", sched)
+	store.Add("mynewsletter", sched)
 	scrapeConfig := scrape.Config{
 		ScheduleStore: store,
 		TickCh:        ch,
@@ -487,14 +533,19 @@ func TestTestModeFlag(t *testing.T) {
 				SMTPServerHost: hostport[0],
 				SMTPServerPort: hostport[1],
 			},
-			LinkSources: u,
-			Scraping: userconfig.Scraping{
-				TestMode: true, // This is important here
-				Schedule: userconfig.NotificationSchedule{
-					Weekdays: userconfig.Monday,
-					Hour:     12,
+			Newsletters: map[string]userconfig.Newsletter{
+				"mynewsletter": userconfig.Newsletter{
+					LinkSources: u,
+					Schedule: userconfig.NotificationSchedule{
+						Weekdays: userconfig.Monday,
+						Hour:     12,
+					},
 				},
+			},
+			Scraping: userconfig.Scraping{
+				TestMode:       true, // This is important here
 				StorageDirPath: testenv.tempDirPath,
+				NewsletterName: "mynewsletter",
 			},
 		},
 	)
@@ -573,14 +624,19 @@ func TestOneOffFlag(t *testing.T) {
 				SMTPServerHost: hostport[0],
 				SMTPServerPort: hostport[1],
 			},
-			LinkSources: u,
-			Scraping: userconfig.Scraping{
-				Schedule: userconfig.NotificationSchedule{
-					Weekdays: userconfig.Monday,
-					Hour:     12,
+			Newsletters: map[string]userconfig.Newsletter{
+				"mynewsletter": userconfig.Newsletter{
+					LinkSources: u,
+					Schedule: userconfig.NotificationSchedule{
+						Weekdays: userconfig.Monday,
+						Hour:     12,
+					},
 				},
+			},
+			Scraping: userconfig.Scraping{
 				StorageDirPath: testenv.tempDirPath,
 				OneOff:         true, // This is important here
+				NewsletterName: "mynewsletter",
 			},
 		},
 	)
@@ -663,15 +719,20 @@ func TestOneOffFlagWithNoEmailFlag(t *testing.T) {
 				SMTPServerHost: hostport[0],
 				SMTPServerPort: hostport[1],
 			},
-			LinkSources: u,
+			Newsletters: map[string]userconfig.Newsletter{
+				"mynewsletter": userconfig.Newsletter{
+					LinkSources: u,
+					Schedule: userconfig.NotificationSchedule{
+						Weekdays: userconfig.Monday,
+						Hour:     12,
+					},
+				},
+			},
 			Scraping: userconfig.Scraping{
 				// Note that both TestMode and OneOff are true here.
-				TestMode: true,
-				OneOff:   true,
-				Schedule: userconfig.NotificationSchedule{
-					Weekdays: userconfig.Monday,
-					Hour:     12,
-				},
+				TestMode:       true,
+				OneOff:         true,
+				NewsletterName: "mynewsletter",
 				StorageDirPath: testenv.tempDirPath,
 			},
 		},
@@ -717,4 +778,118 @@ func TestOneOffFlagWithNoEmailFlag(t *testing.T) {
 		)
 	}
 
+}
+
+func TestMultipleNewsletterEmailSending(t *testing.T) {
+	epubs := 3
+	linksPerPub := 5
+	testenv, err := startTestEnvironment(t, testEnvironmentConfig{
+		numHTTPServers: epubs,
+		numLinks:       linksPerPub,
+	})
+	defer testenv.tearDown()
+	if err != nil {
+		t.Fatalf("error starting test environment: %v", err)
+	}
+
+	scheds := []userconfig.NotificationSchedule{
+		{
+			Weekdays: userconfig.Monday,
+			Hour:     12,
+		},
+		{
+			Weekdays: userconfig.Monday,
+			Hour:     15,
+		},
+		{
+			Weekdays: userconfig.Monday,
+			Hour:     20,
+		},
+	}
+
+	ticks := make([]time.Time, len(scheds))
+	for i, s := range scheds {
+		t, err := time.Parse(time.DateOnly, "2025-06-09")
+		if err != nil {
+			panic(err) // Shouldn't be an error since there's a hardcoded input
+		}
+
+		ticks[i] = t.Add(time.Duration(s.Hour) * time.Hour)
+	}
+
+	// Configure link site checks for each fake e-publicaiton we've spun up.
+	urls := testenv.urls()
+	srcs := make([]linksrc.Config, len(urls), len(urls))
+	for i := range urls {
+		// not expecting errors since these URLs are guaranteed to be
+		// for running servers, and don't come from user input
+		pu, _ := url.Parse(urls[i])
+
+		srcs[i] = linksrc.Config{
+			URL:  *pu,
+			Name: fmt.Sprintf("site-%v", pu.Port()),
+		}
+	}
+
+	store := userconfig.NewScheduleStore()
+	newsletters := make(map[string]userconfig.Newsletter)
+	for i, c := range srcs {
+		nl := fmt.Sprintf("mynewsletter%v", i)
+		newsletters[nl] = userconfig.Newsletter{
+			LinkSources: []linksrc.Config{
+				c,
+			},
+			Schedule: scheds[i],
+		}
+		store.Add(nl, scheds[i])
+	}
+
+	hostport := strings.Split(testenv.SMTPServer.Address(), ":")
+	config, err := createUserConfig(
+		userconfig.Meta{
+			EmailSettings: email.UserConfig{
+				SMTPServerHost: hostport[0],
+				SMTPServerPort: hostport[1],
+			},
+			Newsletters: newsletters,
+			Scraping: userconfig.Scraping{
+				StorageDirPath: testenv.tempDirPath,
+			},
+		},
+	)
+	if err != nil {
+		panic(fmt.Sprintf("can't create the app config: %v", err))
+	}
+
+	ch := make(chan time.Time, 1)
+	scrapeConfig := scrape.Config{
+		ScheduleStore: store,
+		TickCh:        ch,
+	}
+
+	go func() {
+		for i := range ticks {
+			ch <- ticks[i]
+		}
+		close(ch)
+	}()
+
+	scrape.StartLoop(&scrapeConfig, &config)
+
+	ems, err := testenv.SMTPServer.RetrieveEmails(0)
+
+	if err != nil {
+		t.Errorf("can't retrieve email from the test SMTP server: %v", err)
+	}
+
+	expectedCount := len(scheds) + 1
+	// There should be one email per polling interval, plus the initial
+	// email (which is sent right away).
+	if len(ems) != expectedCount {
+		t.Errorf(
+			"expecting %v emails but got %v",
+			expectedCount,
+			len(ems),
+		)
+	}
 }

--- a/e2e/test-server-group.go
+++ b/e2e/test-server-group.go
@@ -131,7 +131,7 @@ func startTestServerGroup(numServers int, numLinks int) *testServerGroup {
 	for i := range servs {
 		servs[i] = fakeEPublication{
 			numLinks: numLinks,
-			id:       uuid.NewString(),
+			id:       fmt.Sprintf("fakepub-%v", i),
 			updates:  make(map[int64][]mockArticleListing),
 		}
 		// the first update

--- a/email/email.go
+++ b/email/email.go
@@ -40,7 +40,6 @@ type UserConfig struct {
 // CheckAndSetDefaults validates s and either returns a copy of c with default
 // settings applied or returns an error due to an invalid configuration
 func (c *UserConfig) CheckAndSetDefaults() (UserConfig, error) {
-
 	uc := *c
 
 	if c.SkipCertVerification == true {
@@ -142,7 +141,6 @@ func (uc *UserConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // `text/html` type in asHTML. A lack of an error means the message was
 // received by the destination SMTP server.
 func (uc UserConfig) SendNewsletter(asText, asHTML []byte) error {
-
 	auth := smtp.PlainAuth("", uc.UserName, uc.Password, uc.SMTPServerHost)
 
 	// Write the email body. It will have the following MIME entities.

--- a/html/emailbody.go
+++ b/html/emailbody.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/ptgott/one-newsletter/linksrc"
+	"github.com/ptgott/one-newsletter/userconfig"
 )
 
 // BodySectionContent is used to populate email body templates
@@ -37,9 +38,6 @@ func NewBodySectionContent(s linksrc.Set) BodySectionContent {
 }
 
 // Template meant to be populated with a []linksrc.Set
-// Using tables for layout to avoid cross-client irregularities.
-// See here for best practices:
-// https://www.smashingmagazine.com/2017/01/introduction-building-sending-html-email-for-web-developers/#using-html-tables-for-layout
 const emailBodyHTML = `<html>
 <head>
 </head>
@@ -71,18 +69,18 @@ const emailBodyText = `{{ range . }}
 {{ end }}
 `
 
-// EmailData contains metadata for the body of an email to send
+// NewsletterEmailData contains metadata for the body of an email to send
 // with a newsletter etc. Since each linksrc.Set in linksets
 // comes from a different upstream, this is designed to support
 // concurrent access. You should create this with NewEmailData.
-type EmailData struct {
+type NewsletterEmailData struct {
 	content []BodySectionContent
 	mtx     *sync.Mutex
 }
 
-// NewEmailData safely creates an EmailData.
-func NewEmailData() *EmailData {
-	return &EmailData{
+// NewNewsletterEmailData safely creates an EmailData.
+func NewNewsletterEmailData() *NewsletterEmailData {
+	return &NewsletterEmailData{
 		content: []BodySectionContent{},
 		mtx:     &sync.Mutex{},
 	}
@@ -91,7 +89,7 @@ func NewEmailData() *EmailData {
 // Add stores a new linksrc.Set in the EmailData in a
 // goroutine-safe way. Callers must use Add for adding
 // linksrc.Sets to the EmailData.
-func (ed *EmailData) Add(s linksrc.Set) {
+func (ed *NewsletterEmailData) Add(s linksrc.Set) {
 	ed.mtx.Lock()
 	defer ed.mtx.Unlock()
 
@@ -100,7 +98,7 @@ func (ed *EmailData) Add(s linksrc.Set) {
 
 // populateEmailTemplate executes a package-local template with the provided
 // EmailData and performs any last-minute checks needed to do this.
-func populateEmailTemplate(ed *EmailData, tmp string) string {
+func populateEmailTemplate(ed *NewsletterEmailData, tmp string) string {
 	ed.mtx.Lock()
 	defer ed.mtx.Unlock()
 
@@ -116,7 +114,7 @@ func populateEmailTemplate(ed *EmailData, tmp string) string {
 // content. It's meant to include multiple sources of links in the same
 // email to reduce the number of emails we send. Any scraping- or parsing-
 // related error messages are included in the text.
-func (ed *EmailData) GenerateBody() string {
+func (ed *NewsletterEmailData) GenerateBody() string {
 	return populateEmailTemplate(ed, emailBodyHTML)
 }
 
@@ -124,6 +122,86 @@ func (ed *EmailData) GenerateBody() string {
 // content, satisfying the text/plain MIME type. It's meant to include multiple
 // sources of links in the same email to reduce the number of emails we send.
 // Any scraping- or parsing- related error messages are included in the text.
-func (ed *EmailData) GenerateText() string {
+func (ed *NewsletterEmailData) GenerateText() string {
 	return populateEmailTemplate(ed, emailBodyText)
+}
+
+// SummaryContent includes configuration details for a newsletter. Used to
+// summarize all configured newsletters in an initial email.
+type SummaryContent struct {
+	Name     string
+	Schedule string
+}
+
+// SummaryEmailData contains information for summarizing all configured
+// newsletters in an initial email.
+type SummaryEmailData struct {
+	Content []SummaryContent
+	mtx     *sync.Mutex
+}
+
+func NewSummaryEmailData(m *userconfig.Meta) SummaryEmailData {
+	content := make([]SummaryContent, len(m.Newsletters))
+	var i int
+	for k, n := range m.Newsletters {
+		content[i] = SummaryContent{
+			Name:     k,
+			Schedule: n.Schedule.String(),
+		}
+		i++
+	}
+	return SummaryEmailData{
+		Content: content,
+		mtx:     &sync.Mutex{},
+	}
+}
+
+// populateSummaryEmailTemplate executes a package-local template with the
+// provided SummaryEmailData and performs any last-minute checks needed to do this.
+func populateSummaryEmailTemplate(ed *SummaryEmailData, tmp string) string {
+	ed.mtx.Lock()
+	defer ed.mtx.Unlock()
+
+	var str strings.Builder
+	// The template text is constant, so suppressing the error
+	tmpl, _ := template.New("body").Parse(tmp)
+	tmpl.Execute(&str, ed.Content)
+
+	return str.String()
+}
+
+// summaryEmailBodyText is a template meant to be populated with a
+// []SummaryContent.  Meant to satisfy the text/plain MIME type.
+const summaryEmailBodyText = `You have configured the following newsletters:
+{{ range . -}}
+- {{.Name}}: {{.Schedule}}
+{{ end }}
+`
+
+// Template meant to be populated with a []SummaryContent.
+// Using tables for layout to avoid cross-client irregularities.
+const summaryEmailBodyHTML = `<html>
+<head>
+</head>
+<body>
+	<p>You have configured the following newsletters:</p>
+	<ul>
+	{{ range . }}
+	    <li>{{.Name}}: {{.Schedule}}</li>
+	{{ end }}
+	</ul>
+</body>
+</html>`
+
+// GenerateText produces an email body to send based on the unformatted
+// content, satisfying the text/plain MIME type. It's meant to include a summary
+// of configured newsletters to include in an initial email.
+func (ed *SummaryEmailData) GenerateText() string {
+	return populateSummaryEmailTemplate(ed, summaryEmailBodyText)
+}
+
+// GenerateBody produces an HTML email body to send based on the unformatted
+// content.
+func (ed *SummaryEmailData) GenerateBody() string {
+	return populateSummaryEmailTemplate(ed, summaryEmailBodyHTML)
 }

--- a/html/emailbody_test.go
+++ b/html/emailbody_test.go
@@ -7,20 +7,52 @@ import (
 	"testing"
 
 	"github.com/ptgott/one-newsletter/linksrc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+// Paths for golden file tests. To update a golden file, delete it and run the
+// test again.
 const (
-	relativeGoldenHTMLFilePath string = "golden-email-body.html"
-	relativeGoldenTextFilePath string = "golden-email-body.txt"
+	relativeGoldenHTMLFilePath        string = "golden-email-body.html"
+	relativeGoldenTextFilePath        string = "golden-email-body.txt"
+	relativeGoldenTextSummaryFilePath string = "golden-email-summary-body.txt"
+	relativeGoldenHTMLSummaryFilePath string = "golden-email-summary-body.html"
 )
 
-// GenerateBody straightforwardly populates a template and takes no input. As
-// a result, there's not much that can go wrong. Still, we want to catch
-// regressions, so we'll use a golden file here. To update the golden file,
-// delete the file at $relativeGoldenHTMLFilePath before running this test. Edits
-// to the golden file should be checked into version control.
-func TestGenerateBody(t *testing.T) {
-	ed := EmailData{
+// testGoldenFile opens the file at path or, if it doesn't exist, creates it
+// with expected. If the file exists, checks expected against the content of the
+// file.
+func testGoldenFile(t *testing.T, path string, expected string) {
+	_, err := os.Stat(path)
+
+	// This will always be an *os.PathError
+	// https://golang.org/pkg/os/#Stat
+	if err != nil {
+		// not handling the error since it will only be a path error in
+		// os.openFileNoLog, which os.Create wraps via os.OpenFile.
+		gf, _ := os.Create(path)
+		defer gf.Close()
+
+		_, err = gf.Write([]byte(expected))
+		require.NoError(t, err)
+
+		// Don't check the in-memory HTML against the file we just created
+		return
+	}
+
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+
+	var content bytes.Buffer
+	_, err = content.ReadFrom(f)
+	require.NoError(t, err)
+	assert.Equal(t, expected, content.String())
+}
+
+func TestNewsletterEmailData_GenerateBody(t *testing.T) {
+	ed := NewsletterEmailData{
 		mtx: &sync.Mutex{},
 		content: []BodySectionContent{
 			{
@@ -59,50 +91,11 @@ func TestGenerateBody(t *testing.T) {
 	}
 
 	h := ed.GenerateBody()
-
-	_, err := os.Stat(relativeGoldenHTMLFilePath)
-
-	// This will always be an *os.PathError
-	// https://golang.org/pkg/os/#Stat
-	if err != nil {
-		// not handling the error since it will only be a path error in
-		// os.openFileNoLog, which os.Create wraps via os.OpenFile.
-		gf, _ := os.Create(relativeGoldenHTMLFilePath)
-		defer gf.Close()
-
-		_, err = gf.Write([]byte(h))
-
-		if err != nil {
-			t.Errorf("couldn't write to the golden file: %v", err)
-		}
-		// Don't check the in-memory HTML against the file we just created
-		return
-	}
-
-	f, err := os.Open(relativeGoldenHTMLFilePath)
-
-	if err != nil {
-		t.Errorf("couldn't open the golden file for reading: %v", err)
-	}
-
-	var content bytes.Buffer
-	_, err = content.ReadFrom(f)
-	if err != nil {
-		t.Errorf("couldn't read from the golden file %v", relativeGoldenHTMLFilePath)
-	}
-	if string(content.Bytes()) != h {
-		t.Errorf("the HTML generated from GenerateBody does not match the golden file at %v", relativeGoldenHTMLFilePath)
-	}
-
+	testGoldenFile(t, relativeGoldenHTMLFilePath, h)
 }
 
-// GenerateText straightforwardly populates a template and takes no input. As
-// a result, there's not much that can go wrong. Still, we want to catch
-// regressions, so we'll use a golden file here. To update the golden file,
-// delete the file at $relativeGoldenTextFilePath before running this test. Edits
-// to the golden file should be checked into version control.
-func TestGenerateText(t *testing.T) {
-	ed := EmailData{
+func TestNewsletterEmailData_GenerateText(t *testing.T) {
+	ed := NewsletterEmailData{
 		mtx: &sync.Mutex{},
 		content: []BodySectionContent{
 			{
@@ -141,40 +134,51 @@ func TestGenerateText(t *testing.T) {
 	}
 
 	h := ed.GenerateText()
+	testGoldenFile(t, relativeGoldenTextFilePath, h)
+}
 
-	_, err := os.Stat(relativeGoldenTextFilePath)
-
-	// This will always be an *os.PathError
-	// https://golang.org/pkg/os/#Stat
-	if err != nil {
-		// not handling the error since it will only be a path error in
-		// os.openFileNoLog, which os.Create wraps via os.OpenFile.
-		gf, _ := os.Create(relativeGoldenTextFilePath)
-		defer gf.Close()
-
-		_, err = gf.Write([]byte(h))
-
-		if err != nil {
-			t.Errorf("couldn't write to the golden file: %v", err)
-		}
-
-		// Don't check the in-memory text against the file we just created
-		return
-
+func TestSummaryEmailData_GenerateText(t *testing.T) {
+	sd := SummaryEmailData{
+		mtx: &sync.Mutex{},
+		Content: []SummaryContent{
+			{
+				Name:     "News",
+				Schedule: "Mondays, Thursdays at 13:00",
+			},
+			{
+				Name:     "Jokes",
+				Schedule: "Wednesdays at 16:00",
+			},
+			{
+				Name:     "Events",
+				Schedule: "Fridays at 12:00",
+			},
+		},
 	}
 
-	f, err := os.Open(relativeGoldenTextFilePath)
+	h := sd.GenerateText()
+	testGoldenFile(t, relativeGoldenTextSummaryFilePath, h)
+}
 
-	if err != nil {
-		t.Errorf("couldn't open the golden file for reading: %v", err)
+func TestSummaryEmailData_GenerateBody(t *testing.T) {
+	sd := SummaryEmailData{
+		mtx: &sync.Mutex{},
+		Content: []SummaryContent{
+			{
+				Name:     "News",
+				Schedule: "Mondays, Thursdays at 13:00",
+			},
+			{
+				Name:     "Jokes",
+				Schedule: "Wednesdays at 16:00",
+			},
+			{
+				Name:     "Events",
+				Schedule: "Fridays at 12:00",
+			},
+		},
 	}
 
-	var content bytes.Buffer
-	_, err = content.ReadFrom(f)
-	if err != nil {
-		t.Errorf("couldn't read from the golden file %v", relativeGoldenTextFilePath)
-	}
-	if string(content.Bytes()) != h {
-		t.Errorf("the text generated from GenerateBody does not match the golden file at %v", relativeGoldenTextFilePath)
-	}
+	h := sd.GenerateBody()
+	testGoldenFile(t, relativeGoldenHTMLSummaryFilePath, h)
 }

--- a/html/golden-email-summary-body.html
+++ b/html/golden-email-summary-body.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+</head>
+<body>
+	<p>You have configured the following newsletters:</p>
+	<ul>
+	
+	    <li>News: Mondays, Thursdays at 13:00</li>
+	
+	    <li>Jokes: Wednesdays at 16:00</li>
+	
+	    <li>Events: Fridays at 12:00</li>
+	
+	</ul>
+</body>
+</html>

--- a/html/golden-email-summary-body.txt
+++ b/html/golden-email-summary-body.txt
@@ -1,0 +1,5 @@
+You have configured the following newsletters:
+- News: Mondays, Thursdays at 13:00
+- Jokes: Wednesdays at 16:00
+- Events: Fridays at 12:00
+

--- a/main.go
+++ b/main.go
@@ -46,6 +46,11 @@ func main() {
 		false,
 		"Run the scrapers and send a single email. Used for testing a live One Newsletter deployment. Does not touch the database.",
 	)
+	name := flag.String(
+		"name",
+		"",
+		"Name of the newsletter to run in test or one-off mode. Must be present in the configuration file.",
+	)
 	level := flag.String(
 		"level",
 		"",
@@ -96,6 +101,7 @@ func main() {
 	}
 	config.Scraping.OneOff = *oneOff
 	config.Scraping.TestMode = *testMode
+	config.Scraping.NewsletterName = *name
 
 	checkedConfig, err := config.CheckAndSetDefaults()
 	if err != nil {
@@ -106,7 +112,9 @@ func main() {
 	}
 
 	sched := userconfig.NewScheduleStore()
-	sched.Add(userconfig.DefaultScheduleName, checkedConfig.Scraping.Schedule)
+	for k, v := range checkedConfig.Newsletters {
+		sched.Add(k, v.Schedule)
+	}
 
 	log.Info().Str("configPath", *configPath).Msg("successfully validated the config")
 

--- a/scrape/scrape.go
+++ b/scrape/scrape.go
@@ -2,11 +2,13 @@ package scrape
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/ptgott/one-newsletter/email"
 	"github.com/ptgott/one-newsletter/html"
 	"github.com/ptgott/one-newsletter/linksrc"
 	"github.com/ptgott/one-newsletter/storage"
@@ -28,7 +30,7 @@ type Config struct {
 // encountered. It reads the user config anew at the beginning of each cycle. At
 // the end of a scrape cycle, it sends an email or, depending on the config,
 // writes a plaintext version of the email message to outwr.
-func Run(outwr io.Writer, config *userconfig.Meta) error {
+func Run(outwr io.Writer, scraping userconfig.Scraping, emailSettings email.UserConfig, newsletter userconfig.Newsletter) error {
 	httpClient := http.Client{
 		// Determined arbitrarily. We don't want to wait forever for a
 		// request to complete, but the cadence of the newsletter means
@@ -37,13 +39,13 @@ func Run(outwr io.Writer, config *userconfig.Meta) error {
 	}
 
 	var db storage.KeyValue
-	if config.Scraping.TestMode || config.Scraping.OneOff {
+	if scraping.TestMode || scraping.OneOff {
 		db = &storage.NoOpDB{}
 	} else {
 		var err error
 		db, err = storage.NewBadgerDB(
-			config.Scraping.StorageDirPath,
-			time.Duration(config.Scraping.LinkExpiryDays*24)*time.Hour,
+			scraping.StorageDirPath,
+			time.Duration(scraping.LinkExpiryDays*24)*time.Hour,
 		)
 		if err != nil {
 			return err
@@ -52,17 +54,16 @@ func Run(outwr io.Writer, config *userconfig.Meta) error {
 
 	log.Info().Msg("set up the database connection successfully")
 	log.Info().
-		Int("count", len(config.LinkSources)).
 		Msg("launching scrapers")
 	var wg sync.WaitGroup
-	d := html.NewEmailData()
+	d := html.NewNewsletterEmailData()
 
 	// buffer the results of the latest scrape so we can perform a diff
 	// with the previous scrape and build an email body
-	emailBuildCh := make(chan linksrc.Set, len(config.LinkSources))
-	wg.Add(len(config.LinkSources))
+	emailBuildCh := make(chan linksrc.Set, len(newsletter.LinkSources))
+	wg.Add(len(newsletter.LinkSources))
 	var ec chan error
-	for _, ls := range config.LinkSources {
+	for _, ls := range newsletter.LinkSources {
 		go func(
 			lc linksrc.Config,
 			g *sync.WaitGroup,
@@ -151,7 +152,7 @@ func Run(outwr io.Writer, config *userconfig.Meta) error {
 	txt := d.GenerateText()
 	log.Info().Msg("attempting to send an email")
 
-	if config.Scraping.TestMode {
+	if scraping.TestMode {
 		if outwr == nil {
 			log.Warn().Msg(
 				"a writer is unavailable for receiving the output message",
@@ -163,7 +164,7 @@ func Run(outwr io.Writer, config *userconfig.Meta) error {
 			}
 		}
 	} else {
-		err = config.EmailSettings.SendNewsletter([]byte(txt), []byte(bod))
+		err = emailSettings.SendNewsletter([]byte(txt), []byte(bod))
 		if err != nil {
 			log.Error().Err(err).Msg("error sending an email")
 		}
@@ -176,15 +177,24 @@ func Run(outwr io.Writer, config *userconfig.Meta) error {
 // interval as specified in the provided config. If an s.ErrCh is provided,
 // sends any errors to it. Send a struct{} to sc to stop the scraper.
 func StartLoop(s *Config, c *userconfig.Meta) error {
-	// Run the first scrape immediately
-	err := Run(s.OutputWr, c)
-	if err != nil {
-		return err
+	// Only running the loop once for the specified newsletter
+	if c.Scraping.OneOff || c.Scraping.TestMode {
+		n, ok := c.Newsletters[c.Scraping.NewsletterName]
+		if !ok {
+			return fmt.Errorf("cannot find a configuration for a newsletter named %q", c.Scraping.NewsletterName)
+		}
+		err := Run(s.OutputWr, c.Scraping, c.EmailSettings, n)
+		if err != nil {
+			return err
+		}
+
+		return nil
 	}
 
-	// Only running the loop once
-	if c.Scraping.OneOff || c.Scraping.TestMode {
-		return nil
+	// Send a confirmation email that summarizes the configured newsletters.
+	summary := html.NewSummaryEmailData(c)
+	if err := c.EmailSettings.SendNewsletter([]byte(summary.GenerateText()), []byte(summary.GenerateBody())); err != nil {
+		return err
 	}
 
 	for {
@@ -194,18 +204,17 @@ func StartLoop(s *Config, c *userconfig.Meta) error {
 		}
 		newsletters := s.ScheduleStore.Get(tk)
 
-		// This is awkward now, but when we make it possible to
-		// send multiple newsletters, we can pass a map of
-		// newsletter names to configs to StartLoop, then look
-		// up each newsletter name from the map to determine
-		// which newsletters to send.
-		if len(newsletters) == 0 {
-			continue
+		for _, n := range newsletters {
+			l, ok := c.Newsletters[n]
+			if !ok {
+				return fmt.Errorf("unable to find a configuration for newsletter %v - this is a bug", n)
+			}
+			err := Run(s.OutputWr, c.Scraping, c.EmailSettings, l)
+			if err != nil {
+				return err
+			}
 		}
-		err := Run(s.OutputWr, c)
-		if err != nil {
-			return err
-		}
+
 	}
 	return nil
 }

--- a/userconfig/userconfig.go
+++ b/userconfig/userconfig.go
@@ -23,7 +23,8 @@ import (
 type Meta struct {
 	Scraping      Scraping         `yaml:"scraping"`
 	EmailSettings email.UserConfig `yaml:"email"`
-	LinkSources   []linksrc.Config `yaml:"link_sources"`
+	// Newsletters is a map of newsletter names to newsletter configs
+	Newsletters map[string]Newsletter `yaml:"newsletters"`
 }
 
 // Weekdays is a bitmap indicating the days of the week in which to send a
@@ -50,6 +51,16 @@ var allDays [7]Weekdays = [7]Weekdays{
 	Sunday,
 }
 
+var daysToString map[Weekdays]string = map[Weekdays]string{
+	Monday:    "Mondays",
+	Tuesday:   "Tuesdays",
+	Wednesday: "Wednesdays",
+	Thursday:  "Thursdays",
+	Friday:    "Fridays",
+	Saturday:  "Saturdays",
+	Sunday:    "Sundays",
+}
+
 var daysToTime map[Weekdays]time.Weekday = map[Weekdays]time.Weekday{
 	Monday:    time.Monday,
 	Tuesday:   time.Tuesday,
@@ -65,6 +76,20 @@ const DefaultScheduleName = "newsletter"
 type NotificationSchedule struct {
 	Weekdays Weekdays
 	Hour     int
+}
+
+func (n NotificationSchedule) String() string {
+	var s strings.Builder
+	var days []string
+	for _, d := range allDays {
+		if n.Weekdays&d == 0 {
+			continue
+		}
+		days = append(days, daysToString[d])
+		s.WriteString(strings.Join(days, ", "))
+	}
+	s.WriteString(" at " + strconv.Itoa(n.Hour) + ":00")
+	return s.String()
 }
 
 // Moment specifies attributes of a time as returned by methods of
@@ -143,16 +168,23 @@ func (s *ScheduleStore) Get(t time.Time) []string {
 // Scraping contains config options that apply to One Newsletter's scraping
 // behavior
 type Scraping struct {
-	Schedule       NotificationSchedule
 	StorageDirPath string
-	// Run the scraper once, then exit
-	OneOff bool
-	// Print the HTML body of a single email to stdout and exit to help test
+	// OneOff runs the scraper once, then exits
+	OneOff bool `yaml:"one_off"`
+	// TestMode prints the HTML body of a single email to stdout and exit to help test
 	// configuration.
-	TestMode bool
-	// Number of days we keep a link in the database before marking it
-	// expired.
+	TestMode bool `yaml:"test_mode"`
+	// NewsletterName indicates the name of the newsletter to send in
+	// one-off or test mode.
+	NewsletterName string `yaml:"newsletter_name"`
+	// LinkExpiryDay is the number of days we keep a link in the database
+	// before marking it expired.
 	LinkExpiryDays uint
+}
+
+type Newsletter struct {
+	Schedule    NotificationSchedule
+	LinkSources []linksrc.Config `yaml:"link_sources"`
 }
 
 // CheckAndSetDefaults validates s and either returns a copy of s with default
@@ -197,17 +229,21 @@ func (s *Scraping) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	s.LinkExpiryDays = uint(lid)
 
-	ni, ok := v["schedule"]
-	if !ok {
-		return errors.New("the configuration must provide a notification schedule")
+	return nil
+}
+
+func (n *NotificationSchedule) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var v string
+	if err := unmarshal(&v); err != nil {
+		return errors.New("notification schedule is not a string")
 	}
 
-	n, err := parseNotificationSchedule(ni)
+	s, err := parseNotificationSchedule(v)
 	if err != nil {
-		return fmt.Errorf("cannot parse the notification schedule: %w", err)
+		return fmt.Errorf("invalid notification schedule: %w", err)
 	}
-	s.Schedule = n
 
+	n = &s
 	return nil
 }
 
@@ -228,13 +264,21 @@ func (m *Meta) CheckAndSetDefaults() (Meta, error) {
 	}
 	c.EmailSettings = e
 
-	c.LinkSources = make([]linksrc.Config, len(m.LinkSources))
-	for n, s := range m.LinkSources {
-		ns, err := s.CheckAndSetDefaults()
-		if err != nil {
-			return Meta{}, err
+	c.Newsletters = make(map[string]Newsletter)
+	for i, v := range m.Newsletters {
+		nn := Newsletter{
+			LinkSources: make([]linksrc.Config, len(v.LinkSources)),
+			Schedule:    v.Schedule,
 		}
-		c.LinkSources[n] = ns
+		for p, s := range v.LinkSources {
+			ns, err := s.CheckAndSetDefaults()
+			if err != nil {
+				return Meta{}, err
+			}
+			nn.LinkSources[p] = ns
+		}
+
+		c.Newsletters[i] = nn
 	}
 
 	return c, nil
@@ -261,8 +305,16 @@ func Parse(r io.Reader) (*Meta, error) {
 		return &Meta{}, errors.New("must include a \"scraping\" section")
 	}
 
-	if len(m.LinkSources) == 0 {
-		return &Meta{}, errors.New("must include at least one item within \"link_sources\"")
+	if len(m.Newsletters) == 0 {
+		return &Meta{}, errors.New("must include at least one item within \"newsletters\"")
+	}
+
+	// TODO: Move the link sources checking into the unmarshaler for
+	// userconfig.Newsletter
+	for _, n := range m.Newsletters {
+		if len(n.LinkSources) == 0 {
+			return &Meta{}, errors.New("must include at least one item within \"link_sources\"")
+		}
 	}
 
 	// Since this is a one-off or a test, set the data directory to an

--- a/userconfig/userconfig_test.go
+++ b/userconfig/userconfig_test.go
@@ -34,15 +34,19 @@ email:
     toAddress: recipient@example.com
     username: MyUser123
     password: 123456-A_BCDE
-link_sources:
-    - name: site-38911
-      url: http://127.0.0.1:38911
-      itemSelector: "ul li"
-      captionSelector: "p"
-      linkSelector: "a"
 scraping:
     schedule: "M 12"
-    storageDir: ./tempTestDir3012705204`,
+    storageDir: ./tempTestDir3012705204
+newsletters:
+  mynewsletter:
+    schedule: MWF 12
+    link_sources:
+      - name: site-38911
+        url: http://127.0.0.1:38911
+        itemSelector: "ul li"
+        captionSelector: "p"
+        linkSelector: "a"
+`,
 		},
 		{
 			description:   "no email section",
@@ -60,7 +64,7 @@ scraping:
     storageDir: ./tempTestDir3012705204`,
 		},
 		{
-			description:   "no link_sources section",
+			description:   "no newsletters section",
 			shouldBeError: true,
 			shouldBeEmpty: true,
 			conf: `---
@@ -109,13 +113,18 @@ email:
     toAddress: recipient@example.com
     username: MyUser123
     password: 123456-A_BCDE
-link_sources:
-    - name: site-38911
-      url: http://127.0.0.1:38911
-      linkSelector: "a"
 scraping:
     schedule: "M 12"
-    storageDir: ./tempTestDir3012705204`,
+    storageDir: ./tempTestDir3012705204
+newsletters:
+  mynewsletter:
+    schedule: MWF 12
+    link_sources:
+        - name: site-38911
+          url: http://127.0.0.1:38911
+          linkSelector: "a"
+    
+`,
 		},
 		{
 			description:   "valid link source with no link selector",
@@ -128,12 +137,16 @@ email:
     toAddress: recipient@example.com
     username: MyUser123
     password: 123456-A_BCDE
-link_sources:
-    - name: site-38911
-      url: http://127.0.0.1:38911
 scraping:
     schedule: "M 13"
-    storageDir: ./tempTestDir3012705204`,
+    storageDir: ./tempTestDir3012705204
+newsletters:
+  mynewsletter:
+    schedule: MWF 12
+    link_sources:
+        - name: site-38911
+          url: http://127.0.0.1:38911
+`,
 		},
 	}
 
@@ -181,17 +194,12 @@ func TestScrapingUnmarshalYAML(t *testing.T) {
 			shouldBeError: false,
 			input: `storageDir: ./tempTestDir3012705204
 linkExpiryDays: 100
-schedule: "M 12"
 `,
 			expected: Scraping{
 				StorageDirPath: "./tempTestDir3012705204",
 				OneOff:         false,
 				TestMode:       false,
 				LinkExpiryDays: 100,
-				Schedule: NotificationSchedule{
-					Weekdays: Monday,
-					Hour:     12,
-				},
 			},
 		},
 		{
@@ -199,13 +207,6 @@ schedule: "M 12"
 			shouldBeError: true,
 			input:         `[]`,
 			expected:      Scraping{},
-		},
-		{
-			description:   "unparseable duration",
-			shouldBeError: true,
-			input: `interval: 5y
-storageDir: ./tempTestDir3012705204`,
-			expected: Scraping{},
 		},
 	}
 
@@ -403,7 +404,7 @@ func TestGet(t *testing.T) {
 		}
 		actual := s.Get(m)
 
-		assert.Equal(t, expected, actual)
+		assert.ElementsMatch(t, expected, actual)
 	})
 
 	t.Run("successive identical gets", func(t *testing.T) {
@@ -560,6 +561,29 @@ func Test_parseNotificationSchedule_invalid(t *testing.T) {
 		t.Run(c.description, func(t *testing.T) {
 			_, err := parseNotificationSchedule(c.input)
 			assert.ErrorContains(t, err, c.errSubstring)
+		})
+	}
+}
+
+func TestNotificationScheduleString(t *testing.T) {
+	cases := []struct {
+		description string
+		input       NotificationSchedule
+		expected    string
+	}{
+		{
+			description: "single weekday",
+			input: NotificationSchedule{
+				Weekdays: Friday,
+				Hour:     12,
+			},
+			expected: "Fridays at 12:00",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			assert.Equal(t, c.expected, c.input.String())
 		})
 	}
 }


### PR DESCRIPTION
Make it possible for One Newsletter to send different newsletters on different schedules. This prevents newsletters sent by One Newsletter from getting too long and unwieldy, makes it possible to send newsletters extracted from some sources more frequently than others, and allows users to group newsletters by theme.

Add a `name` flag so users running One Newsletter with the `oneoff` flag can choose a newsletter to send.

Since there are multiple newsletters, the email that One Newsletter sends on startup is a summary of the newsletters, rather than the first issue of a newsletter.

Implementation details:

- Add a `Newsletter` type and move  the notification schedule field into it from `Scraping`.
- Change the `Newsletters` config field to a map of strings to newsletters. This makes it straightforward to look up a newsletter based on retrieving it from `ScheduleStore`.
- Rename `EmailData` to `NewsletterEmailData` so we can distinguish this from the initial email with a confirmation and summary of newsletters.